### PR TITLE
Refactor navigation logic into dedicated hook

### DIFF
--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -1,3 +1,5 @@
+import { AppView } from "../types/view";
+import { ComponentType } from "react";
 import {
   Sidebar,
   SidebarContent,
@@ -20,8 +22,8 @@ import {
 } from 'lucide-react';
 
 interface AppSidebarProps {
-  currentView: string;
-  onNavigate: (view: string) => void;
+  currentView: AppView;
+  onNavigate: (view: AppView) => void;
   onNewCase: () => void;
 }
 
@@ -30,7 +32,12 @@ export function AppSidebar({
   onNavigate, 
   onNewCase
 }: AppSidebarProps) {
-  const menuItems = [
+  const menuItems: Array<{
+    title: string;
+    icon: ComponentType<{ className?: string }>;
+    view: AppView;
+    id: string;
+  }> = [
     {
       title: "Dashboard",
       icon: LayoutDashboard,
@@ -40,7 +47,7 @@ export function AppSidebar({
     {
       title: "Cases",
       icon: Users,
-      view: "cases", 
+      view: "list",
       id: "cases",
     },
     {
@@ -51,16 +58,11 @@ export function AppSidebar({
     },
   ];
 
-  const isActiveItem = (itemView: string) => {
-    if (itemView === 'dashboard') {
-      return currentView === 'dashboard';
-    }
-    if (itemView === 'cases') {
+  const isActiveItem = (itemId: string, itemView: AppView) => {
+    if (itemId === 'cases') {
       return ['list', 'details', 'form'].includes(currentView);
     }
-    if (itemView === 'settings') {
-      return currentView === 'settings';
-    }
+
     return currentView === itemView;
   };
 
@@ -82,7 +84,7 @@ export function AppSidebar({
                 <SidebarMenuItem key={item.id}>
                   <SidebarMenuButton
                     onClick={() => onNavigate(item.view)}
-                    isActive={isActiveItem(item.view)}
+                    isActive={isActiveItem(item.id, item.view)}
                   >
                     <item.icon className="h-4 w-4" />
                     <span>{item.title}</span>

--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -35,36 +35,34 @@ export function AppSidebar({
   const menuItems: Array<{
     title: string;
     icon: ComponentType<{ className?: string }>;
-    view: AppView;
+    navigateTo: AppView;
+    activeViews: AppView[];
     id: string;
   }> = [
     {
       title: "Dashboard",
       icon: LayoutDashboard,
-      view: "dashboard",
+      navigateTo: "dashboard",
+      activeViews: ["dashboard"],
       id: "dashboard",
     },
     {
       title: "Cases",
       icon: Users,
-      view: "list",
+      navigateTo: "list",
+      activeViews: ["list", "details", "form"],
       id: "cases",
     },
     {
       title: "Settings",
       icon: Settings,
-      view: "settings",
+      navigateTo: "settings",
+      activeViews: ["settings"],
       id: "settings",
     },
   ];
 
-  const isActiveItem = (itemId: string, itemView: AppView) => {
-    if (itemId === 'cases') {
-      return ['list', 'details', 'form'].includes(currentView);
-    }
-
-    return currentView === itemView;
-  };
+  const isActiveItem = (views: AppView[]) => views.includes(currentView);
 
   return (
     <Sidebar variant="inset">
@@ -83,8 +81,8 @@ export function AppSidebar({
               {menuItems.map((item) => (
                 <SidebarMenuItem key={item.id}>
                   <SidebarMenuButton
-                    onClick={() => onNavigate(item.view)}
-                    isActive={isActiveItem(item.id, item.view)}
+                    onClick={() => onNavigate(item.navigateTo)}
+                    isActive={isActiveItem(item.activeViews)}
                   >
                     <item.icon className="h-4 w-4" />
                     <span>{item.title}</span>

--- a/components/MainLayout.tsx
+++ b/components/MainLayout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { AppView } from '../types/view';
 import { SidebarProvider, SidebarInset, SidebarTrigger } from './ui/sidebar';
 import { AppSidebar } from './AppSidebar';
 import { Separator } from './ui/separator';
@@ -6,8 +7,8 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage } from './ui
 
 interface MainLayoutProps {
   children: ReactNode;
-  currentView: string;
-  onNavigate: (view: string) => void;
+  currentView: AppView;
+  onNavigate: (view: AppView) => void;
   onNewCase: () => void;
   breadcrumbTitle?: string;
   sidebarOpen?: boolean;

--- a/components/routing/ViewRenderer.tsx
+++ b/components/routing/ViewRenderer.tsx
@@ -1,4 +1,5 @@
 import { CaseDisplay, NewPersonData, NewCaseRecordData } from "../../types/case";
+import { AppView } from "../../types/view";
 
 // Direct imports for high-turnover components - no lazy loading for snappiness
 import Dashboard from "../Dashboard";
@@ -7,7 +8,7 @@ import CaseDetails from "../CaseDetails";
 import CaseForm from "../CaseForm";
 import Settings from "../Settings";
 
-export type View = 'dashboard' | 'list' | 'details' | 'form' | 'settings';
+export type View = AppView;
 
 interface ViewRendererProps {
   // View state

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -9,6 +9,9 @@ export { useCaseManagement } from './useCaseManagement';
 // File system connection flow
 export { useConnectionFlow } from './useConnectionFlow';
 
+// Navigation flow
+export { useNavigationFlow } from './useNavigationFlow';
+
 // Financial item flow
 export { useFinancialItemFlow } from './useFinancialItemFlow';
 

--- a/hooks/useNavigationFlow.ts
+++ b/hooks/useNavigationFlow.ts
@@ -23,7 +23,7 @@ interface NavigationHandlers {
   editingCase: CaseDisplay | null;
   sidebarOpen: boolean;
   breadcrumbTitle?: string;
-  navigate: (view: string) => void;
+  navigate: (view: AppView) => void;
   viewCase: (caseId: string) => void;
   editCase: (caseId: string) => void;
   newCase: () => void;
@@ -160,7 +160,7 @@ export function useNavigationFlow({
   );
 
   const navigate = useCallback(
-    (view: string) => {
+    (view: AppView) => {
       if (view === "details" || view === "form") {
         setSidebarOpen(false);
       } else {
@@ -172,7 +172,6 @@ export function useNavigationFlow({
           backToDashboard();
           break;
         case "list":
-        case "cases":
           backToList();
           break;
         case "form":

--- a/hooks/useNavigationFlow.ts
+++ b/hooks/useNavigationFlow.ts
@@ -1,0 +1,210 @@
+import { useCallback, useMemo, useState } from "react";
+import { CaseDisplay, NewCaseRecordData, NewPersonData } from "../types/case";
+import { AppView } from "../types/view";
+
+interface FormState {
+  previousView: AppView;
+  returnToCaseId?: string;
+}
+
+interface UseNavigationFlowParams {
+  cases: CaseDisplay[];
+  saveCase: (
+    caseData: { person: NewPersonData; caseRecord: NewCaseRecordData },
+    editingCase?: CaseDisplay | null
+  ) => Promise<void>;
+  deleteCase: (caseId: string) => Promise<void>;
+}
+
+interface NavigationHandlers {
+  currentView: AppView;
+  selectedCaseId: string | null;
+  selectedCase: CaseDisplay | undefined;
+  editingCase: CaseDisplay | null;
+  sidebarOpen: boolean;
+  breadcrumbTitle?: string;
+  navigate: (view: string) => void;
+  viewCase: (caseId: string) => void;
+  editCase: (caseId: string) => void;
+  newCase: () => void;
+  saveCaseWithNavigation: (
+    caseData: { person: NewPersonData; caseRecord: NewCaseRecordData }
+  ) => Promise<void>;
+  cancelForm: () => void;
+  deleteCaseWithNavigation: (caseId: string) => Promise<void>;
+  backToList: () => void;
+  backToDashboard: () => void;
+  setSidebarOpen: (open: boolean) => void;
+}
+
+export function useNavigationFlow({
+  cases,
+  saveCase,
+  deleteCase,
+}: UseNavigationFlowParams): NavigationHandlers {
+  const [currentView, setCurrentView] = useState<AppView>("dashboard");
+  const [selectedCaseId, setSelectedCaseId] = useState<string | null>(null);
+  const [editingCase, setEditingCase] = useState<CaseDisplay | null>(null);
+  const [formState, setFormState] = useState<FormState>({ previousView: "list" });
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(true);
+
+  const selectedCase = useMemo(
+    () => cases.find((c) => c.id === selectedCaseId),
+    [cases, selectedCaseId]
+  );
+
+  const breadcrumbTitle = useMemo(() => {
+    if (currentView === "details" && selectedCase) {
+      return `${selectedCase.person.firstName} ${selectedCase.person.lastName}`;
+    }
+    return undefined;
+  }, [currentView, selectedCase]);
+
+  const backToList = useCallback(() => {
+    setCurrentView("list");
+    setSelectedCaseId(null);
+  }, []);
+
+  const backToDashboard = useCallback(() => {
+    setCurrentView("dashboard");
+    setSelectedCaseId(null);
+  }, []);
+
+  const viewCase = useCallback((caseId: string) => {
+    setSelectedCaseId(caseId);
+    setCurrentView("details");
+    setSidebarOpen(false);
+  }, []);
+
+  const editCase = useCallback(
+    (caseId: string) => {
+      const caseToEdit = cases.find((c) => c.id === caseId);
+      if (!caseToEdit) {
+        return;
+      }
+
+      setEditingCase(caseToEdit);
+      setFormState({
+        previousView: currentView,
+        returnToCaseId: currentView === "details" ? caseId : undefined,
+      });
+      setCurrentView("form");
+      setSidebarOpen(false);
+    },
+    [cases, currentView]
+  );
+
+  const newCase = useCallback(() => {
+    setEditingCase(null);
+    setFormState({
+      previousView: currentView,
+      returnToCaseId: undefined,
+    });
+    setCurrentView("form");
+    setSidebarOpen(false);
+  }, [currentView]);
+
+  const saveCaseWithNavigation = useCallback(
+    async (caseData: { person: NewPersonData; caseRecord: NewCaseRecordData }) => {
+      try {
+        await saveCase(caseData, editingCase);
+
+        if (editingCase) {
+          if (formState.previousView === "details" && formState.returnToCaseId) {
+            setSelectedCaseId(formState.returnToCaseId);
+            setCurrentView("details");
+          } else {
+            setCurrentView(formState.previousView);
+          }
+        } else {
+          setCurrentView("list");
+        }
+
+        setEditingCase(null);
+        setFormState({ previousView: "list" });
+      } catch (err) {
+        console.error("Failed to save case in navigation flow wrapper:", err);
+        throw err;
+      }
+    },
+    [editingCase, formState, saveCase]
+  );
+
+  const cancelForm = useCallback(() => {
+    if (formState.previousView === "details" && formState.returnToCaseId) {
+      setSelectedCaseId(formState.returnToCaseId);
+      setCurrentView("details");
+    } else {
+      setCurrentView(formState.previousView);
+    }
+
+    setEditingCase(null);
+    setFormState({ previousView: "list" });
+  }, [formState]);
+
+  const deleteCaseWithNavigation = useCallback(
+    async (caseId: string) => {
+      try {
+        await deleteCase(caseId);
+
+        if (selectedCaseId === caseId) {
+          setCurrentView("list");
+          setSelectedCaseId(null);
+        }
+      } catch (err) {
+        console.error("Failed to delete case in navigation flow wrapper:", err);
+        throw err;
+      }
+    },
+    [deleteCase, selectedCaseId]
+  );
+
+  const navigate = useCallback(
+    (view: string) => {
+      if (view === "details" || view === "form") {
+        setSidebarOpen(false);
+      } else {
+        setSidebarOpen(true);
+      }
+
+      switch (view) {
+        case "dashboard":
+          backToDashboard();
+          break;
+        case "list":
+        case "cases":
+          backToList();
+          break;
+        case "form":
+          newCase();
+          break;
+        case "settings":
+          setCurrentView("settings");
+          setSelectedCaseId(null);
+          break;
+        default:
+          backToDashboard();
+      }
+    },
+    [backToDashboard, backToList, newCase]
+  );
+
+  return {
+    currentView,
+    selectedCaseId,
+    selectedCase,
+    editingCase,
+    sidebarOpen,
+    breadcrumbTitle,
+    navigate,
+    viewCase,
+    editCase,
+    newCase,
+    saveCaseWithNavigation,
+    cancelForm,
+    deleteCaseWithNavigation,
+    backToList,
+    backToDashboard,
+    setSidebarOpen,
+  };
+}

--- a/hooks/useNavigationFlow.ts
+++ b/hooks/useNavigationFlow.ts
@@ -161,31 +161,40 @@ export function useNavigationFlow({
 
   const navigate = useCallback(
     (view: AppView) => {
-      if (view === "details" || view === "form") {
-        setSidebarOpen(false);
-      } else {
-        setSidebarOpen(true);
-      }
-
       switch (view) {
         case "dashboard":
+          setSidebarOpen(true);
           backToDashboard();
-          break;
+          return;
         case "list":
+          setSidebarOpen(true);
           backToList();
-          break;
+          return;
+        case "details":
+          if (selectedCaseId) {
+            setSidebarOpen(false);
+            setCurrentView("details");
+          } else {
+            setSidebarOpen(true);
+            backToList();
+          }
+          return;
         case "form":
+          setSidebarOpen(false);
           newCase();
-          break;
+          return;
         case "settings":
+          setSidebarOpen(true);
           setCurrentView("settings");
           setSelectedCaseId(null);
-          break;
-        default:
-          backToDashboard();
+          return;
+        default: {
+          const exhaustiveCheck: never = view;
+          return exhaustiveCheck;
+        }
       }
     },
-    [backToDashboard, backToList, newCase]
+    [backToDashboard, backToList, newCase, selectedCaseId]
   );
 
   return {

--- a/types/view.ts
+++ b/types/view.ts
@@ -1,0 +1,1 @@
+export type AppView = 'dashboard' | 'list' | 'details' | 'form' | 'settings';


### PR DESCRIPTION
## Summary
- extract navigation/view state management into new \ hook
- share an \ union for routing and update \
- simplify \ to consume the hook and trim redundant handlers

## Testing
- npm test -- --run