### PR TITLE
Add RTL coverage for key flows and document test guidelines

### DIFF
--- a/__tests__/integration/connectionFlow.test.tsx
+++ b/__tests__/integration/connectionFlow.test.tsx
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "@/App";
+import { toast as mockToast } from "@/src/test/testUtils";
+
+const initialFileData = vi.hoisted(() => ({
+  exported_at: "2024-01-01T00:00:00.000Z",
+  total_cases: 1,
+  cases: [
+    {
+      id: "case-initial",
+      name: "Existing Case",
+      mcn: "MCN-1234",
+      status: "In Progress",
+      priority: false,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+      person: {
+        id: "person-initial",
+        firstName: "Existing",
+        lastName: "Case",
+        name: "Existing Case",
+        email: "existing@example.com",
+        phone: "555-000-0000",
+        dateOfBirth: "1990-01-01",
+        ssn: "***-**-0000",
+        organizationId: null,
+        livingArrangement: "Apartment/House",
+        address: {
+          street: "123 Main St",
+          city: "Omaha",
+          state: "NE",
+          zip: "68102",
+        },
+        mailingAddress: {
+          street: "123 Main St",
+          city: "Omaha",
+          state: "NE",
+          zip: "68102",
+          sameAsPhysical: true,
+        },
+        authorizedRepIds: [],
+        familyMembers: [],
+        status: "Active",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        dateAdded: "2024-01-01T00:00:00.000Z",
+      },
+      caseRecord: {
+        id: "case-record-initial",
+        mcn: "MCN-1234",
+        applicationDate: "2024-01-02",
+        caseType: "LTC",
+        personId: "person-initial",
+        spouseId: "",
+        status: "In Progress",
+        description: "Initial description",
+        priority: false,
+        livingArrangement: "Apartment/House",
+        withWaiver: false,
+        admissionDate: "2024-01-03",
+        organizationId: "",
+        authorizedReps: [],
+        retroRequested: "",
+        financials: {
+          resources: [],
+          income: [],
+          expenses: [],
+        },
+        notes: [],
+        createdDate: "2024-01-01T00:00:00.000Z",
+        updatedDate: "2024-01-01T00:00:00.000Z",
+      },
+    },
+  ],
+}));
+
+const serviceState = vi.hoisted(() => ({
+  data: JSON.parse(JSON.stringify(initialFileData)),
+  lastWrite: null as any,
+  lastSaveTime: null as number | null,
+}));
+
+vi.mock("@/utils/AutosaveFileService", () => {
+  const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value));
+
+  class MockAutosaveFileService {
+    private statusCallback?: (status: any) => void;
+    private dataLoadCallback?: (data: any) => void;
+    private status = {
+      status: "waiting",
+      message: "Awaiting connection",
+      timestamp: Date.now(),
+      permissionStatus: "granted",
+      lastSaveTime: null,
+      consecutiveFailures: 0,
+    };
+
+    constructor(config: { statusCallback?: (status: any) => void } = {}) {
+      this.statusCallback = config.statusCallback;
+      this.emitStatus("waiting", "Awaiting connection", "granted");
+    }
+
+    private emitStatus(status: string, message: string, permissionStatus: string) {
+      this.status = {
+        status,
+        message,
+        timestamp: Date.now(),
+        permissionStatus,
+        lastSaveTime: serviceState.lastSaveTime,
+        consecutiveFailures: 0,
+      };
+      this.statusCallback?.({ ...this.status });
+    }
+
+    isSupported() {
+      return true;
+    }
+
+    getStatus() {
+      return { ...this.status, isRunning: this.status.status === "running" };
+    }
+
+    updateConfig() {
+      // No-op for tests
+    }
+
+    startAutosave() {
+      this.emitStatus("running", "Autosave started", this.status.permissionStatus);
+    }
+
+    stopAutosave() {
+      this.emitStatus("connected", "Autosave stopped", this.status.permissionStatus);
+    }
+
+    async connect() {
+      this.emitStatus("connected", "Connected to folder", "granted");
+      return true;
+    }
+
+    async connectToExisting() {
+      this.emitStatus("running", "Reconnected", "granted");
+      return true;
+    }
+
+    async disconnect() {
+      this.emitStatus("disconnected", "Disconnected", "prompt");
+    }
+
+    destroy() {
+      // No-op cleanup hook for tests
+    }
+
+    async save() {
+      serviceState.lastSaveTime = Date.now();
+      this.emitStatus("running", "Saved", this.status.permissionStatus);
+    }
+
+    async ensurePermission() {
+      return true;
+    }
+
+    async listDataFiles() {
+      return ["case-tracker-data.json"];
+    }
+
+    async readNamedFile() {
+      return null;
+    }
+
+    async readFile() {
+      return clone(serviceState.data);
+    }
+
+    async writeFile(data: any) {
+      serviceState.data = clone(data);
+      serviceState.lastWrite = serviceState.data;
+      this.emitStatus("running", "Saved", "granted");
+      return true;
+    }
+
+    async loadExistingData() {
+      const data = clone(serviceState.data);
+      this.dataLoadCallback?.(data);
+      return data;
+    }
+
+    async loadDataFromFile() {
+      return this.loadExistingData();
+    }
+
+    initializeWithReactState() {
+      // Not required for the integration test
+    }
+
+    setDataLoadCallback(callback: (data: any) => void) {
+      this.dataLoadCallback = callback;
+    }
+
+    notifyDataChange() {
+      if (this.dataLoadCallback) {
+        this.dataLoadCallback(clone(serviceState.data));
+      }
+    }
+  }
+
+  return { default: MockAutosaveFileService };
+});
+
+describe("connect → load → edit → save flow", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes("(prefers-color-scheme: dark)"),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    class MockResizeObserver {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+
+    class MockIntersectionObserver {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+
+    Object.defineProperty(window, "ResizeObserver", {
+      writable: true,
+      value: MockResizeObserver,
+    });
+    Object.defineProperty(window, "IntersectionObserver", {
+      writable: true,
+      value: MockIntersectionObserver,
+    });
+
+    // Keep Node global references in sync for Radix internals
+    // @ts-expect-error - assigning to global for test environment
+    global.ResizeObserver = MockResizeObserver;
+    // @ts-expect-error - assigning to global for test environment
+    global.IntersectionObserver = MockIntersectionObserver;
+
+    serviceState.data = JSON.parse(JSON.stringify(initialFileData));
+    serviceState.lastWrite = null;
+    serviceState.lastSaveTime = null;
+    mockToast.success.mockClear();
+    mockToast.error.mockClear();
+    mockToast.loading.mockClear();
+    window.location.hash = "";
+  });
+
+  it("connects to storage, loads cases, edits a record, and persists changes", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const connectButton = await screen.findByRole("button", { name: /connect to previous folder/i });
+    await user.click(connectButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    await screen.findByRole("heading", { name: /dashboard/i });
+    await screen.findByText(/MCN: MCN-1234/i);
+
+    await user.click(screen.getByRole("button", { name: /^view all$/i }));
+    await screen.findByRole("heading", { name: /case management/i });
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const firstNameInput = await screen.findByLabelText(/first name/i);
+    await user.clear(firstNameInput);
+    await user.type(firstNameInput, "Updated");
+
+    const saveButton = screen.getByRole("button", { name: /update case/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /update case/i })).not.toBeInTheDocument();
+    });
+
+    await screen.findByText(/case for updated case updated successfully/i);
+
+    expect(serviceState.lastWrite).toBeTruthy();
+    expect(serviceState.lastWrite.cases[0].person.firstName).toBe("Updated");
+    expect(serviceState.lastWrite.cases[0].name).toBe("Updated Case");
+  });
+});

--- a/components/__tests__/CaseForm.test.tsx
+++ b/components/__tests__/CaseForm.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CaseForm } from "@/components/case/CaseForm";
+import { createMockCaseDisplay, createMockPerson, createMockCaseRecord } from "@/src/test/testUtils";
+
+describe("CaseForm", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("disables save until required fields are filled and calls onSave with normalized payload", async () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CaseForm onSave={onSave} onCancel={onCancel} />);
+
+    const saveButton = screen.getByRole("button", { name: /create case/i });
+    expect(saveButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/first name/i), "Alice");
+    await user.type(screen.getByLabelText(/last name/i), "Smith");
+    await user.type(screen.getByLabelText(/email/i), "alice@example.com");
+    await user.type(screen.getByLabelText(/phone/i), "5551234567");
+    await user.type(screen.getByLabelText(/mcn/i), "MCN-1");
+
+    // Application date defaults to today, but ensure the control has a value for clarity
+    const applicationDateInput = screen.getByLabelText(/application date/i) as HTMLInputElement;
+    expect(applicationDateInput.value).not.toBe("");
+
+    expect(saveButton).not.toBeDisabled();
+    await user.click(saveButton);
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const payload = onSave.mock.calls[0][0];
+
+    expect(payload.person).toMatchObject({
+      firstName: "Alice",
+      lastName: "Smith",
+      email: "alice@example.com",
+      phone: "5551234567",
+      authorizedRepIds: [],
+      familyMembers: [],
+    });
+
+    expect(payload.caseRecord).toMatchObject({
+      mcn: "MCN-1",
+      retroRequested: "",
+    });
+  });
+
+  it("renders editing state with existing data and calls onCancel when cancelled", async () => {
+    const existingCase = createMockCaseDisplay({
+      id: "case-123",
+      person: createMockPerson({
+        firstName: "Existing",
+        lastName: "Client",
+        email: "existing@example.com",
+        phone: "555-111-2222",
+      }),
+      caseRecord: createMockCaseRecord({
+        id: "record-123",
+        mcn: "MCN-Existing",
+      }),
+    });
+
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CaseForm case={existingCase} onSave={onSave} onCancel={onCancel} />);
+
+    expect(screen.getByDisplayValue("Existing")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("MCN-Existing")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/__tests__/ConnectToExistingModal.test.tsx
+++ b/components/__tests__/ConnectToExistingModal.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConnectToExistingModal } from "@/components/modals/ConnectToExistingModal";
+
+describe("ConnectToExistingModal", () => {
+  it("informs users when the File System Access API is unavailable", () => {
+    render(
+      <ConnectToExistingModal
+        isOpen
+        isSupported={false}
+        onConnectToExisting={vi.fn()}
+        onChooseNewFolder={vi.fn()}
+        onGoToSettings={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(/browser not supported/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/requires the File System Access API/i)
+    ).toBeInTheDocument();
+  });
+
+  it("handles reconnecting to a stored folder", async () => {
+    const onConnectToExisting = vi.fn().mockResolvedValue(true);
+    const onChooseNewFolder = vi.fn().mockResolvedValue(true);
+    const user = userEvent.setup();
+
+    render(
+      <ConnectToExistingModal
+        isOpen
+        isSupported
+        hasStoredHandle
+        permissionStatus="granted"
+        onConnectToExisting={onConnectToExisting}
+        onChooseNewFolder={onChooseNewFolder}
+        onGoToSettings={vi.fn()}
+      />
+    );
+
+    const connectButton = screen.getByRole("button", { name: /connect to previous folder/i });
+    await user.click(connectButton);
+
+    expect(screen.getByText(/reconnecting/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(onConnectToExisting).toHaveBeenCalledTimes(1);
+    });
+
+    // After the promise resolves the loading label should disappear
+    await waitFor(() => {
+      expect(screen.queryByText(/reconnecting/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("surfaces connection failures returned by the storage hooks", async () => {
+    const onConnectToExisting = vi.fn().mockResolvedValue(false);
+    const onChooseNewFolder = vi.fn().mockResolvedValue(true);
+    const user = userEvent.setup();
+
+    render(
+      <ConnectToExistingModal
+        isOpen
+        isSupported
+        hasStoredHandle
+        permissionStatus="prompt"
+        onConnectToExisting={onConnectToExisting}
+        onChooseNewFolder={onChooseNewFolder}
+        onGoToSettings={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /connect to previous folder/i }));
+
+    await waitFor(() => {
+      expect(onConnectToExisting).toHaveBeenCalled();
+    });
+
+    expect(
+      await screen.findByText(/failed to connect to existing directory/i)
+    ).toBeInTheDocument();
+  });
+
+  it("delegates to folder selection when requested", async () => {
+    const onConnectToExisting = vi.fn().mockResolvedValue(true);
+    const onChooseNewFolder = vi.fn().mockResolvedValue(true);
+    const onGoToSettings = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ConnectToExistingModal
+        isOpen
+        isSupported
+        hasStoredHandle={false}
+        onConnectToExisting={onConnectToExisting}
+        onChooseNewFolder={onChooseNewFolder}
+        onGoToSettings={onGoToSettings}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /choose data folder/i }));
+
+    await waitFor(() => {
+      expect(onChooseNewFolder).toHaveBeenCalledTimes(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: /go to settings/i }));
+    expect(onGoToSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/__tests__/FinancialItemCard.test.tsx
+++ b/components/__tests__/FinancialItemCard.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FinancialItemCard } from "@/components/financial/FinancialItemCard";
+import { createMockFinancialItem } from "@/src/test/testUtils";
+
+const createItem = () =>
+  createMockFinancialItem("income", {
+    id: "income-1",
+    description: "Salary",
+    amount: 2500,
+    verificationStatus: "Needs VR",
+    frequency: "monthly",
+  });
+
+describe("FinancialItemCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("opens in edit mode when clicked and persists changes on save", async () => {
+    const item = createItem();
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FinancialItemCard
+        item={item}
+        itemType="income"
+        onDelete={onDelete}
+        onUpdate={onUpdate}
+      />
+    );
+
+    expect(screen.queryByLabelText(/description/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByText(/salary/i));
+    const descriptionField = await screen.findByLabelText(/description/i);
+    await user.clear(descriptionField);
+    await user.type(descriptionField, "Updated salary");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith(
+        "income",
+        "income-1",
+        expect.objectContaining({ description: "Updated salary" })
+      );
+    });
+  });
+
+  it("allows cancelling edits without persisting changes", async () => {
+    const item = createItem();
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FinancialItemCard
+        item={item}
+        itemType="income"
+        onDelete={onDelete}
+        onUpdate={onUpdate}
+      />
+    );
+
+    await user.click(screen.getByText(/salary/i));
+    const descriptionField = await screen.findByLabelText(/description/i);
+    await user.clear(descriptionField);
+    await user.type(descriptionField, "Cancelled change");
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/description/i)).not.toBeInTheDocument();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("confirms deletion before invoking onDelete", async () => {
+    const item = createItem();
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+
+    const { container } = render(
+      <FinancialItemCard
+        item={item}
+        itemType="income"
+        onDelete={onDelete}
+        onUpdate={onUpdate}
+        isEditing
+      />
+    );
+
+    const deleteTrigger = container.querySelector(
+      ".financial-item-delete-btn"
+    ) as HTMLButtonElement;
+    expect(deleteTrigger).toBeTruthy();
+
+    await user.click(deleteTrigger);
+
+    const confirmButton = container.querySelector(
+      ".financial-item-confirm-btn--approve"
+    ) as HTMLButtonElement;
+    expect(confirmButton).toBeTruthy();
+
+    await user.click(confirmButton);
+
+    expect(onDelete).toHaveBeenCalledWith("income", "income-1");
+  });
+
+  it("updates verification status through the dropdown menu", async () => {
+    const item = createItem();
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FinancialItemCard
+        item={item}
+        itemType="income"
+        onDelete={onDelete}
+        onUpdate={onUpdate}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /needs vr/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /verified/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith(
+        "income",
+        "income-1",
+        expect.objectContaining({ verificationStatus: "Verified" })
+      );
+    });
+  });
+});

--- a/docs/development/testing-infrastructure.md
+++ b/docs/development/testing-infrastructure.md
@@ -175,6 +175,19 @@ __tests__/
 - **Hook Testing**: Custom hooks with proper mocking
 - **Component Logic**: Pure component behavior without UI integration
 
+## 🧭 **Choosing the Right Testing Approach**
+
+- **React Testing Library (RTL)**
+  - Exercise user-facing workflows end-to-end (e.g., connection onboarding, case editing, modal flows).
+  - Validate component behaviour that depends on context providers, hooks, or browser APIs (File System Access) by stubbing those integrations.
+  - Capture accessibility contracts (labels, roles, focus handling) and regression-proof event wiring.
+- **Headless Vitest Suites**
+  - Cover pure utilities, data normalization, and hooks that operate without DOM dependencies.
+  - Assert business rules, data transformations, and error handling where rendering adds little value.
+- **Integration Hybrids**
+  - Pair RTL with lightweight service doubles (e.g., mock `AutosaveFileService`) when verifying cross-context flows.
+  - Document assumptions inline so filesystem behaviour remains deterministic and repeatable across environments.
+
 #### **2. Integration Tests**
 - **File System Flows**: Complete save/load cycles
 - **Component Integration**: Parent-child component interactions


### PR DESCRIPTION
## Summary
- add React Testing Library coverage for CaseForm, FinancialItemCard, and ConnectToExistingModal
- introduce an integration test for the connect → load → edit → save case workflow with a deterministic file service stub
- expand the testing guide with guidance on when to use RTL, headless suites, and hybrid approaches

## Testing
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68d5fb8a7a408332b6ab5bb2e97a5a90