### PR TITLE
Feature/phase 3 file storage

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,6 +39,13 @@ const AppContent = memo(function AppContent() {
     setHasLoadedData,
   } = useCaseManagement();
   
+  const navigationFlow = useNavigationFlow({
+    cases,
+    connectionState,
+    saveCase,
+    deleteCase,
+  });
+
   const {
     currentView,
     selectedCase,
@@ -54,11 +61,8 @@ const AppContent = memo(function AppContent() {
     deleteCaseWithNavigation: handleDeleteCase,
     backToList: handleBackToList,
     setSidebarOpen,
-  } = useNavigationFlow({
-    cases,
-    saveCase,
-    deleteCase,
-  });
+    navigationLock: _navigationLock,
+  } = navigationFlow;
 
   const {
     showConnectModal,

--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useMemo, memo } from "react";
 import { Toaster } from "./components/ui/sonner";
 import { CaseDisplay, CaseCategory, FinancialItem } from "./types/case";
 import { toast } from "sonner";
-import { useFileStorage } from "./contexts/FileStorageContext";
+import { useFileStorage, useFileStorageLifecycleSelectors } from "./contexts/FileStorageContext";
 import { useDataManagerSafe } from "./contexts/DataManagerContext";
 import {
   useCaseManagement,
@@ -19,7 +19,8 @@ import { useAppContentViewModel } from "./components/app/useAppContentViewModel"
 import { clearFileStorageFlags, updateFileStorageFlags } from "./utils/fileStorageFlags";
 
 const AppContent = memo(function AppContent() {
-  const { isSupported, isConnected, hasStoredHandle, status, connectToFolder, connectToExisting, loadExistingData, service } = useFileStorage();
+  const { isSupported, hasStoredHandle, connectToFolder, connectToExisting, loadExistingData, service } = useFileStorage();
+  const connectionState = useFileStorageLifecycleSelectors();
   
   // Get DataManager instance at component level
   const dataManager = useDataManagerSafe();
@@ -66,9 +67,8 @@ const AppContent = memo(function AppContent() {
     dismissConnectModal,
   } = useConnectionFlow({
     isSupported,
-    isConnected,
-    hasStoredHandle,
     hasLoadedData,
+    connectionState,
     connectToFolder,
     connectToExisting,
     loadExistingData,
@@ -165,7 +165,7 @@ const AppContent = memo(function AppContent() {
 
   // Note: loadCases is now provided by useCaseManagement hook
 
-  useImportListeners({ loadCases, setError });
+  useImportListeners({ loadCases, setError, isStorageReady: connectionState.isReady });
 
   const handleAddItem = useCallback(
     (category: CaseCategory) => {
@@ -348,8 +348,9 @@ const AppContent = memo(function AppContent() {
     showConnectModal,
     isLoading: loading,
     isSupported,
-    permissionStatus: status?.permissionStatus,
+    permissionStatus: connectionState.permissionStatus,
     hasStoredHandle,
+    lifecycle: connectionState.lifecycle,
     navigationState,
     connectionHandlers: {
       onConnectToExisting: handleConnectToExisting,

--- a/__tests__/integration/connectionFlow.test.tsx
+++ b/__tests__/integration/connectionFlow.test.tsx
@@ -140,6 +140,9 @@ vi.mock("@/utils/AutosaveFileService", () => {
 
     async connectToExisting() {
       this.emitStatus("running", "Reconnected", "granted");
+      setTimeout(() => {
+        this.emitStatus("connected", "Connection ready", "granted");
+      }, 0);
       return true;
     }
 

--- a/components/diagnostics/FileStorageSettings.tsx
+++ b/components/diagnostics/FileStorageSettings.tsx
@@ -49,6 +49,7 @@ export function FileStorageSettings() {
   const [isSaving, setIsSaving] = useState(false);
   const [availableFiles, setAvailableFiles] = useState<string[]>([]);
   const [isLoadingFiles, setIsLoadingFiles] = useState(false);
+  const consecutiveFailures = status?.consecutiveFailures ?? 0;
 
   // Debug current state
   console.log('[FileStorageSettings] Render state:', { 
@@ -474,12 +475,12 @@ export function FileStorageSettings() {
         </div>
 
         {/* Status Information */}
-        {status && status.consecutiveFailures > 0 && (
+        {consecutiveFailures > 0 && (
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />
             <AlertDescription>
               <strong>Save Issues Detected</strong><br />
-              {status.consecutiveFailures} consecutive save failure(s). Check your folder connection and permissions.
+              {consecutiveFailures} consecutive save failure(s). Check your folder connection and permissions.
             </AlertDescription>
           </Alert>
         )}

--- a/contexts/FileStorageContext.tsx
+++ b/contexts/FileStorageContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useReducer, ReactNode } from 'react';
 import AutosaveFileService from '@/utils/AutosaveFileService';
 import { setFileService } from '@/utils/fileServiceProvider';
 
@@ -11,11 +11,219 @@ interface FileStorageStatus {
   consecutiveFailures: number;
 }
 
+type FileStorageLifecycleState =
+  | 'uninitialized'
+  | 'unsupported'
+  | 'idle'
+  | 'requestingPermission'
+  | 'ready'
+  | 'saving'
+  | 'blocked'
+  | 'recovering'
+  | 'error';
+
+type FileStoragePermissionState = 'unknown' | 'prompt' | 'granted' | 'denied';
+
+interface FileStorageErrorInfo {
+  message: string;
+  type?: string;
+  timestamp: number;
+}
+
+interface FileStorageMachineState {
+  lifecycle: FileStorageLifecycleState;
+  permissionStatus: FileStoragePermissionState;
+  isSupported: boolean | undefined;
+  hasStoredHandle: boolean;
+  isConnected: boolean;
+  explicitlyConnected: boolean;
+  statusSnapshot: FileStorageStatus | null;
+  lastError: FileStorageErrorInfo | null;
+  lastSaveTime: number | null;
+  consecutiveFailures: number;
+}
+
+type FileStorageAction =
+  | { type: 'SERVICE_INITIALIZED'; supported: boolean }
+  | { type: 'SERVICE_RESET' }
+  | { type: 'STATUS_CHANGED'; status: FileStorageStatus }
+  | { type: 'CONNECT_REQUESTED' }
+  | { type: 'CONNECT_COMPLETED' }
+  | { type: 'CONNECT_CONFIRMED' }
+  | { type: 'PERMISSION_DENIED' }
+  | { type: 'DISCONNECTED' }
+  | { type: 'ERROR_REPORTED'; error: FileStorageErrorInfo };
+
+const initialMachineState: FileStorageMachineState = {
+  lifecycle: 'uninitialized',
+  permissionStatus: 'unknown',
+  isSupported: undefined,
+  hasStoredHandle: false,
+  isConnected: false,
+  explicitlyConnected: false,
+  statusSnapshot: null,
+  lastError: null,
+  lastSaveTime: null,
+  consecutiveFailures: 0,
+};
+
+function normalizePermissionStatus(permission: string | undefined): FileStoragePermissionState {
+  if (permission === 'granted' || permission === 'denied' || permission === 'prompt') {
+    return permission;
+  }
+  return 'unknown';
+}
+
+function computeHasStoredHandle(status: FileStorageStatus, permissionStatus: FileStoragePermissionState): boolean {
+  if (status.status === 'disconnected') {
+    return false;
+  }
+
+  return permissionStatus === 'granted' || permissionStatus === 'prompt';
+}
+
+function deriveLifecycle(
+  baseState: FileStorageMachineState,
+  status: FileStorageStatus,
+  permissionStatus: FileStoragePermissionState,
+): FileStorageLifecycleState {
+  if (baseState.isSupported === false) {
+    return 'unsupported';
+  }
+
+  switch (status.status) {
+    case 'initialized':
+    case 'stopped':
+      return baseState.explicitlyConnected && permissionStatus === 'granted' ? 'ready' : 'idle';
+    case 'connected':
+      return 'ready';
+    case 'running':
+      return baseState.explicitlyConnected && permissionStatus === 'granted' ? 'ready' : baseState.lifecycle === 'requestingPermission' ? 'requestingPermission' : 'idle';
+    case 'waiting':
+      if (permissionStatus === 'denied') {
+        return 'blocked';
+      }
+      return baseState.explicitlyConnected && permissionStatus === 'granted' ? 'ready' : 'idle';
+    case 'retrying':
+      return 'recovering';
+    case 'disconnected':
+      return 'idle';
+    case 'error':
+      return 'error';
+    default:
+      return baseState.lifecycle;
+  }
+}
+
+function reduceFileStorageState(state: FileStorageMachineState, action: FileStorageAction): FileStorageMachineState {
+  switch (action.type) {
+    case 'SERVICE_INITIALIZED':
+      if (!action.supported) {
+        return { ...state, lifecycle: 'unsupported', isSupported: false };
+      }
+      return {
+        ...state,
+        lifecycle: state.lifecycle === 'uninitialized' ? 'idle' : state.lifecycle,
+        isSupported: true,
+      };
+    case 'SERVICE_RESET':
+      return {
+        ...initialMachineState,
+        isSupported: state.isSupported,
+      };
+    case 'CONNECT_REQUESTED':
+      return { ...state, lifecycle: 'requestingPermission' };
+    case 'CONNECT_CONFIRMED':
+      return {
+        ...state,
+        explicitlyConnected: true,
+        isConnected: state.permissionStatus === 'granted' ? true : state.isConnected,
+      };
+    case 'CONNECT_COMPLETED':
+      if (state.explicitlyConnected) {
+        return state;
+      }
+      return {
+        ...state,
+        lifecycle: state.lifecycle === 'requestingPermission' ? 'idle' : state.lifecycle,
+      };
+    case 'PERMISSION_DENIED':
+      return {
+        ...state,
+        lifecycle: 'blocked',
+        permissionStatus: 'denied',
+        explicitlyConnected: false,
+        isConnected: false,
+        hasStoredHandle: false,
+      };
+    case 'DISCONNECTED':
+      return {
+        ...state,
+        lifecycle: 'idle',
+        explicitlyConnected: false,
+        isConnected: false,
+        hasStoredHandle: false,
+      };
+    case 'ERROR_REPORTED':
+      return {
+        ...state,
+        lastError: action.error,
+        lifecycle: action.error.type === 'warning' ? state.lifecycle : 'error',
+      };
+    case 'STATUS_CHANGED': {
+      const permissionStatus = normalizePermissionStatus(action.status.permissionStatus);
+      const hasStoredHandle = computeHasStoredHandle(action.status, permissionStatus);
+
+      let explicitlyConnected = state.explicitlyConnected;
+      let isConnected = state.isConnected;
+
+      if (permissionStatus === 'denied' || action.status.status === 'disconnected') {
+        explicitlyConnected = false;
+        isConnected = false;
+      } else if (explicitlyConnected) {
+        isConnected =
+          permissionStatus === 'granted' &&
+          action.status.status !== 'disconnected' &&
+          action.status.status !== 'error';
+      }
+
+      const baseState: FileStorageMachineState = {
+        ...state,
+        explicitlyConnected,
+        hasStoredHandle,
+      };
+
+      const lifecycle = deriveLifecycle(baseState, action.status, permissionStatus);
+
+      const nextState: FileStorageMachineState = {
+        ...baseState,
+        lifecycle,
+        permissionStatus,
+        isConnected,
+        statusSnapshot: action.status,
+        lastSaveTime: action.status.lastSaveTime ?? null,
+        consecutiveFailures: action.status.consecutiveFailures ?? 0,
+      };
+
+      if (action.status.status !== 'error' && state.lastError) {
+        nextState.lastError = null;
+      }
+
+      return nextState;
+    }
+    default:
+      return state;
+  }
+}
+
 interface FileStorageContextType {
   service: AutosaveFileService | null;
   isSupported: boolean | undefined; // undefined = not initialized yet, boolean = definitive answer
   isConnected: boolean;
   hasStoredHandle: boolean;
+  lifecycle: FileStorageLifecycleState;
+  permissionStatus: FileStoragePermissionState;
+  lastError: FileStorageErrorInfo | null;
   status: FileStorageStatus | null;
   connectToFolder: () => Promise<boolean>;
   connectToExisting: () => Promise<boolean>;
@@ -45,10 +253,7 @@ export function FileStorageProvider({
   onDataLoaded 
 }: FileStorageProviderProps) {
   const [service, setService] = useState<AutosaveFileService | null>(null);
-  const [status, setStatus] = useState<FileStorageStatus | null>(null);
-  const [isConnected, setIsConnected] = useState(false);
-  const [hasExplicitlyConnected, setHasExplicitlyConnected] = useState(false);
-  const [hasStoredHandle, setHasStoredHandle] = useState(false);
+  const [state, dispatch] = useReducer(reduceFileStorageState, initialMachineState);
 
   // Initialize the service - only once per component mount
   useEffect(() => {
@@ -60,20 +265,17 @@ export function FileStorageProvider({
       debounceDelay: 5000,   // 5 seconds
       maxRetries: 3,
       statusCallback: (statusUpdate) => {
-        setStatus(statusUpdate);
-        
-        // Track if we have a stored handle (even if not connected)
-        setHasStoredHandle(
-          (statusUpdate.permissionStatus === 'granted' || statusUpdate.permissionStatus === 'prompt') &&
-          statusUpdate.status !== 'disconnected'
-        );
+        dispatch({ type: 'STATUS_CHANGED', status: statusUpdate });
       },
       errorCallback: (message, type) => {
         console.error(`File storage ${type || 'error'}:`, message);
-        // You could also show a toast notification here
+        if (type !== 'info') {
+          dispatch({ type: 'ERROR_REPORTED', error: { message, type, timestamp: Date.now() } });
+        }
       }
     });
 
+    dispatch({ type: 'SERVICE_INITIALIZED', supported: fileService.isSupported() });
     setService(fileService);
     setFileService(fileService);
 
@@ -81,8 +283,9 @@ export function FileStorageProvider({
       console.log('[FileStorageContext] Destroying AutosaveFileService instance');
       fileService.destroy();
       setFileService(null);
+      dispatch({ type: 'SERVICE_RESET' });
     };
-  }, []); // No dependencies - create only once per component mount
+  }, [dispatch]); // No dependencies - create only once per component mount
 
   // Handle enabled setting separately to avoid service recreation
   useEffect(() => {
@@ -95,23 +298,6 @@ export function FileStorageProvider({
       }
     }
   }, [service, enabled]);
-
-  // Handle connection state separately to avoid service recreation
-  useEffect(() => {
-    if (!status) return;
-    
-    // Only update connection state if we have explicitly connected before
-    if (hasExplicitlyConnected) {
-      if (status.status === 'disconnected' || status.permissionStatus === 'denied') {
-        setIsConnected(false);
-        setHasExplicitlyConnected(false); // Reset explicit connection flag on disconnect
-      } else if (status.permissionStatus === 'granted' && 
-                (status.status === 'connected' || status.status === 'running' || status.status === 'waiting')) {
-        // Any of these statuses with granted permission means we're connected
-        setIsConnected(true);
-      }
-    }
-  }, [status, hasExplicitlyConnected]);
 
   // Handle data provider setup separately to avoid recreating service
   useEffect(() => {
@@ -129,43 +315,64 @@ export function FileStorageProvider({
 
   const connectToFolder = useCallback(async (): Promise<boolean> => {
     if (!service) return false;
+    dispatch({ type: 'CONNECT_REQUESTED' });
     try {
       const success = await service.connect();
       if (success) {
-        setHasExplicitlyConnected(true);
-        setIsConnected(true); // Set connected state for consistency with connectToExisting
+        dispatch({ type: 'CONNECT_CONFIRMED' });
+      } else {
+        dispatch({ type: 'CONNECT_COMPLETED' });
       }
       return success;
     } catch (error) {
       console.error('[FileStorageContext] connectToFolder error:', error);
+      dispatch({
+        type: 'ERROR_REPORTED',
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+          type: 'error',
+          timestamp: Date.now(),
+        },
+      });
+      dispatch({ type: 'CONNECT_COMPLETED' });
       return false;
     }
-  }, [service]);
+  }, [dispatch, service]);
 
   const connectToExisting = useCallback(async (): Promise<boolean> => {
     if (!service) {
       console.error('[FileStorageContext] No service available for connectToExisting');
       return false;
     }
+    dispatch({ type: 'CONNECT_REQUESTED' });
     try {
       const success = await service.connectToExisting();
       if (success) {
-        setHasExplicitlyConnected(true);
-        setIsConnected(true); // Now we're truly connected
+        dispatch({ type: 'CONNECT_CONFIRMED' });
+      } else {
+        dispatch({ type: 'CONNECT_COMPLETED' });
       }
       return success;
     } catch (error) {
       console.error('[FileStorageContext] connectToExisting error:', error);
+      dispatch({
+        type: 'ERROR_REPORTED',
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+          type: 'error',
+          timestamp: Date.now(),
+        },
+      });
+      dispatch({ type: 'CONNECT_COMPLETED' });
       return false;
     }
-  }, [service]);
+  }, [dispatch, service]);
 
-  const disconnect = async (): Promise<void> => {
+  const disconnect = useCallback(async (): Promise<void> => {
     if (!service) return;
     await service.disconnect();
-    setHasExplicitlyConnected(false);
-    setIsConnected(false);
-  };
+    dispatch({ type: 'DISCONNECTED' });
+  }, [dispatch, service]);
 
   const saveNow = async (): Promise<void> => {
     if (!service) return;
@@ -233,28 +440,15 @@ export function FileStorageProvider({
     }
   }, [service]);
 
-  const notifyDataChange = useCallback(() => {
-    if (service) {
-      service.notifyDataChange();
-    }
-  }, [service]);
-
-  // Expose notifyDataChange globally for easy access
-  useEffect(() => {
-    if (service) {
-      window.fileStorageNotifyChange = notifyDataChange;
-    }
-    return () => {
-      delete window.fileStorageNotifyChange;
-    };
-  }, [service, notifyDataChange]);
-
   const contextValue: FileStorageContextType = {
     service,
-    isSupported: service ? service.isSupported() : undefined, // undefined until service is initialized
-    isConnected,
-    hasStoredHandle,
-    status,
+    isSupported: state.isSupported,
+    isConnected: state.isConnected,
+    hasStoredHandle: state.hasStoredHandle,
+    lifecycle: state.lifecycle,
+    permissionStatus: state.permissionStatus,
+    lastError: state.lastError,
+    status: state.statusSnapshot,
     connectToFolder,
     connectToExisting,
     disconnect,

--- a/contexts/FileStorageContext.tsx
+++ b/contexts/FileStorageContext.tsx
@@ -1,220 +1,16 @@
-import { createContext, useContext, useState, useEffect, useCallback, useReducer, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useReducer, ReactNode, useMemo } from 'react';
 import AutosaveFileService from '@/utils/AutosaveFileService';
 import { setFileService } from '@/utils/fileServiceProvider';
-
-interface FileStorageStatus {
-  status: string;
-  message: string;
-  timestamp: number;
-  permissionStatus: string;
-  lastSaveTime: number | null;
-  consecutiveFailures: number;
-}
-
-type FileStorageLifecycleState =
-  | 'uninitialized'
-  | 'unsupported'
-  | 'idle'
-  | 'requestingPermission'
-  | 'ready'
-  | 'saving'
-  | 'blocked'
-  | 'recovering'
-  | 'error';
-
-type FileStoragePermissionState = 'unknown' | 'prompt' | 'granted' | 'denied';
-
-interface FileStorageErrorInfo {
-  message: string;
-  type?: string;
-  timestamp: number;
-}
-
-interface FileStorageMachineState {
-  lifecycle: FileStorageLifecycleState;
-  permissionStatus: FileStoragePermissionState;
-  isSupported: boolean | undefined;
-  hasStoredHandle: boolean;
-  isConnected: boolean;
-  explicitlyConnected: boolean;
-  statusSnapshot: FileStorageStatus | null;
-  lastError: FileStorageErrorInfo | null;
-  lastSaveTime: number | null;
-  consecutiveFailures: number;
-}
-
-type FileStorageAction =
-  | { type: 'SERVICE_INITIALIZED'; supported: boolean }
-  | { type: 'SERVICE_RESET' }
-  | { type: 'STATUS_CHANGED'; status: FileStorageStatus }
-  | { type: 'CONNECT_REQUESTED' }
-  | { type: 'CONNECT_COMPLETED' }
-  | { type: 'CONNECT_CONFIRMED' }
-  | { type: 'PERMISSION_DENIED' }
-  | { type: 'DISCONNECTED' }
-  | { type: 'ERROR_REPORTED'; error: FileStorageErrorInfo };
-
-const initialMachineState: FileStorageMachineState = {
-  lifecycle: 'uninitialized',
-  permissionStatus: 'unknown',
-  isSupported: undefined,
-  hasStoredHandle: false,
-  isConnected: false,
-  explicitlyConnected: false,
-  statusSnapshot: null,
-  lastError: null,
-  lastSaveTime: null,
-  consecutiveFailures: 0,
-};
-
-function normalizePermissionStatus(permission: string | undefined): FileStoragePermissionState {
-  if (permission === 'granted' || permission === 'denied' || permission === 'prompt') {
-    return permission;
-  }
-  return 'unknown';
-}
-
-function computeHasStoredHandle(status: FileStorageStatus, permissionStatus: FileStoragePermissionState): boolean {
-  if (status.status === 'disconnected') {
-    return false;
-  }
-
-  return permissionStatus === 'granted' || permissionStatus === 'prompt';
-}
-
-function deriveLifecycle(
-  baseState: FileStorageMachineState,
-  status: FileStorageStatus,
-  permissionStatus: FileStoragePermissionState,
-): FileStorageLifecycleState {
-  if (baseState.isSupported === false) {
-    return 'unsupported';
-  }
-
-  switch (status.status) {
-    case 'initialized':
-    case 'stopped':
-      return baseState.explicitlyConnected && permissionStatus === 'granted' ? 'ready' : 'idle';
-    case 'connected':
-      return 'ready';
-    case 'running':
-      return baseState.explicitlyConnected && permissionStatus === 'granted' ? 'ready' : baseState.lifecycle === 'requestingPermission' ? 'requestingPermission' : 'idle';
-    case 'waiting':
-      if (permissionStatus === 'denied') {
-        return 'blocked';
-      }
-      return baseState.explicitlyConnected && permissionStatus === 'granted' ? 'ready' : 'idle';
-    case 'retrying':
-      return 'recovering';
-    case 'disconnected':
-      return 'idle';
-    case 'error':
-      return 'error';
-    default:
-      return baseState.lifecycle;
-  }
-}
-
-function reduceFileStorageState(state: FileStorageMachineState, action: FileStorageAction): FileStorageMachineState {
-  switch (action.type) {
-    case 'SERVICE_INITIALIZED':
-      if (!action.supported) {
-        return { ...state, lifecycle: 'unsupported', isSupported: false };
-      }
-      return {
-        ...state,
-        lifecycle: state.lifecycle === 'uninitialized' ? 'idle' : state.lifecycle,
-        isSupported: true,
-      };
-    case 'SERVICE_RESET':
-      return {
-        ...initialMachineState,
-        isSupported: state.isSupported,
-      };
-    case 'CONNECT_REQUESTED':
-      return { ...state, lifecycle: 'requestingPermission' };
-    case 'CONNECT_CONFIRMED':
-      return {
-        ...state,
-        explicitlyConnected: true,
-        isConnected: state.permissionStatus === 'granted' ? true : state.isConnected,
-      };
-    case 'CONNECT_COMPLETED':
-      if (state.explicitlyConnected) {
-        return state;
-      }
-      return {
-        ...state,
-        lifecycle: state.lifecycle === 'requestingPermission' ? 'idle' : state.lifecycle,
-      };
-    case 'PERMISSION_DENIED':
-      return {
-        ...state,
-        lifecycle: 'blocked',
-        permissionStatus: 'denied',
-        explicitlyConnected: false,
-        isConnected: false,
-        hasStoredHandle: false,
-      };
-    case 'DISCONNECTED':
-      return {
-        ...state,
-        lifecycle: 'idle',
-        explicitlyConnected: false,
-        isConnected: false,
-        hasStoredHandle: false,
-      };
-    case 'ERROR_REPORTED':
-      return {
-        ...state,
-        lastError: action.error,
-        lifecycle: action.error.type === 'warning' ? state.lifecycle : 'error',
-      };
-    case 'STATUS_CHANGED': {
-      const permissionStatus = normalizePermissionStatus(action.status.permissionStatus);
-      const hasStoredHandle = computeHasStoredHandle(action.status, permissionStatus);
-
-      let explicitlyConnected = state.explicitlyConnected;
-      let isConnected = state.isConnected;
-
-      if (permissionStatus === 'denied' || action.status.status === 'disconnected') {
-        explicitlyConnected = false;
-        isConnected = false;
-      } else if (explicitlyConnected) {
-        isConnected =
-          permissionStatus === 'granted' &&
-          action.status.status !== 'disconnected' &&
-          action.status.status !== 'error';
-      }
-
-      const baseState: FileStorageMachineState = {
-        ...state,
-        explicitlyConnected,
-        hasStoredHandle,
-      };
-
-      const lifecycle = deriveLifecycle(baseState, action.status, permissionStatus);
-
-      const nextState: FileStorageMachineState = {
-        ...baseState,
-        lifecycle,
-        permissionStatus,
-        isConnected,
-        statusSnapshot: action.status,
-        lastSaveTime: action.status.lastSaveTime ?? null,
-        consecutiveFailures: action.status.consecutiveFailures ?? 0,
-      };
-
-      if (action.status.status !== 'error' && state.lastError) {
-        nextState.lastError = null;
-      }
-
-      return nextState;
-    }
-    default:
-      return state;
-  }
-}
+import {
+  initialMachineState,
+  reduceFileStorageState,
+  readyLifecycleStates,
+  blockingLifecycleStates,
+  type FileStorageStatus,
+  type FileStorageLifecycleState,
+  type FileStoragePermissionState,
+  type FileStorageErrorInfo,
+} from './fileStorageMachine';
 
 interface FileStorageContextType {
   service: AutosaveFileService | null;
@@ -486,3 +282,57 @@ export function useFileStorageDataChange() {
     }
   };
 }
+
+export interface FileStorageLifecycleSelectors {
+  lifecycle: FileStorageLifecycleState;
+  permissionStatus: FileStoragePermissionState;
+  isReady: boolean;
+  isBlocked: boolean;
+  isErrored: boolean;
+  isRecovering: boolean;
+  isAwaitingUserChoice: boolean;
+  hasStoredHandle: boolean;
+  isConnected: boolean;
+  lastError: FileStorageErrorInfo | null;
+}
+
+export function useFileStorageLifecycleSelectors(): FileStorageLifecycleSelectors {
+  const { lifecycle, permissionStatus, hasStoredHandle, lastError, isConnected } = useFileStorage();
+
+  return useMemo(() => {
+    const isReady = readyLifecycleStates.has(lifecycle);
+    const isBlocked = blockingLifecycleStates.has(lifecycle);
+    const isErrored = lifecycle === 'error';
+    const isRecovering = lifecycle === 'recovering';
+    const isAwaitingUserChoice =
+      !isReady &&
+      !isBlocked &&
+      (lifecycle === 'idle' || lifecycle === 'requestingPermission' || permissionStatus === 'prompt');
+
+    return {
+      lifecycle,
+      permissionStatus,
+      isReady,
+      isBlocked,
+      isErrored,
+      isRecovering,
+      isAwaitingUserChoice,
+      hasStoredHandle,
+      isConnected,
+      lastError,
+    };
+  }, [
+    lifecycle,
+    permissionStatus,
+    hasStoredHandle,
+    lastError,
+    isConnected,
+  ]);
+}
+
+export type {
+  FileStorageLifecycleState,
+  FileStoragePermissionState,
+  FileStorageStatus,
+  FileStorageErrorInfo,
+} from './fileStorageMachine';

--- a/contexts/__tests__/fileStorageMachine.test.ts
+++ b/contexts/__tests__/fileStorageMachine.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialMachineState,
+  reduceFileStorageState,
+  type FileStorageStatus,
+} from "../fileStorageMachine";
+
+describe("fileStorageMachine", () => {
+  const baseStatus = (overrides: Partial<FileStorageStatus> = {}): FileStorageStatus => ({
+    status: "initialized",
+    message: "",
+    timestamp: Date.now(),
+    permissionStatus: "prompt",
+    lastSaveTime: null,
+    consecutiveFailures: 0,
+    ...overrides,
+  });
+
+  it("marks service unsupported when initialization reports lack of support", () => {
+    const state = reduceFileStorageState(initialMachineState, {
+      type: "SERVICE_INITIALIZED",
+      supported: false,
+    });
+
+    expect(state.lifecycle).toBe("unsupported");
+    expect(state.isSupported).toBe(false);
+    expect(state.isConnected).toBe(false);
+  });
+
+  it("enters ready state when permission is granted after explicit connection", () => {
+    const supportedState = reduceFileStorageState(initialMachineState, {
+      type: "SERVICE_INITIALIZED",
+      supported: true,
+    });
+
+    const requestingState = reduceFileStorageState(supportedState, { type: "CONNECT_REQUESTED" });
+    const confirmedState = reduceFileStorageState(requestingState, { type: "CONNECT_CONFIRMED" });
+
+    const readyState = reduceFileStorageState(confirmedState, {
+      type: "STATUS_CHANGED",
+      status: baseStatus({ status: "running", permissionStatus: "granted" }),
+    });
+
+    expect(readyState.lifecycle).toBe("ready");
+    expect(readyState.permissionStatus).toBe("granted");
+    expect(readyState.isConnected).toBe(true);
+    expect(readyState.hasStoredHandle).toBe(true);
+  });
+
+  it("transitions to blocked when permission is denied", () => {
+    const supportedState = reduceFileStorageState(initialMachineState, {
+      type: "SERVICE_INITIALIZED",
+      supported: true,
+    });
+
+    const confirmedState = reduceFileStorageState(supportedState, { type: "CONNECT_CONFIRMED" });
+
+    const blockedState = reduceFileStorageState(confirmedState, {
+      type: "STATUS_CHANGED",
+      status: baseStatus({ status: "waiting", permissionStatus: "denied" }),
+    });
+
+    expect(blockedState.lifecycle).toBe("blocked");
+    expect(blockedState.permissionStatus).toBe("denied");
+    expect(blockedState.isConnected).toBe(false);
+    expect(blockedState.hasStoredHandle).toBe(false);
+  });
+
+  it("resets connection flags when disconnected", () => {
+    const supportedState = reduceFileStorageState(initialMachineState, {
+      type: "SERVICE_INITIALIZED",
+      supported: true,
+    });
+
+    const confirmedState = reduceFileStorageState(supportedState, { type: "CONNECT_CONFIRMED" });
+
+    const readyState = reduceFileStorageState(confirmedState, {
+      type: "STATUS_CHANGED",
+      status: baseStatus({ status: "connected", permissionStatus: "granted" }),
+    });
+
+    const disconnectedState = reduceFileStorageState(readyState, { type: "DISCONNECTED" });
+
+    expect(disconnectedState.lifecycle).toBe("idle");
+    expect(disconnectedState.isConnected).toBe(false);
+    expect(disconnectedState.hasStoredHandle).toBe(false);
+    expect(disconnectedState.explicitlyConnected).toBe(false);
+  });
+
+  it("clears stored error when a healthy status arrives", () => {
+    const supportedState = reduceFileStorageState(initialMachineState, {
+      type: "SERVICE_INITIALIZED",
+      supported: true,
+    });
+
+    const erroredState = reduceFileStorageState(supportedState, {
+      type: "ERROR_REPORTED",
+      error: { message: "Autosave failed", timestamp: Date.now() },
+    });
+
+    expect(erroredState.lifecycle).toBe("error");
+    expect(erroredState.lastError?.message).toBe("Autosave failed");
+
+    const recoveredState = reduceFileStorageState(erroredState, {
+      type: "STATUS_CHANGED",
+      status: baseStatus({ status: "running", permissionStatus: "granted" }),
+    });
+
+    expect(recoveredState.lifecycle).toBe("ready");
+    expect(recoveredState.lastError).toBeNull();
+  });
+});

--- a/contexts/fileStorageMachine.ts
+++ b/contexts/fileStorageMachine.ts
@@ -1,0 +1,220 @@
+export interface FileStorageStatus {
+  status: string;
+  message: string;
+  timestamp: number;
+  permissionStatus?: string;
+  lastSaveTime?: number | null;
+  consecutiveFailures?: number;
+}
+
+export type FileStorageLifecycleState =
+  | 'uninitialized'
+  | 'unsupported'
+  | 'idle'
+  | 'requestingPermission'
+  | 'ready'
+  | 'saving'
+  | 'blocked'
+  | 'recovering'
+  | 'error';
+
+export type FileStoragePermissionState = 'unknown' | 'prompt' | 'granted' | 'denied';
+
+export interface FileStorageErrorInfo {
+  message: string;
+  type?: string;
+  timestamp: number;
+}
+
+export interface FileStorageMachineState {
+  lifecycle: FileStorageLifecycleState;
+  permissionStatus: FileStoragePermissionState;
+  isSupported: boolean | undefined;
+  hasStoredHandle: boolean;
+  isConnected: boolean;
+  explicitlyConnected: boolean;
+  statusSnapshot: FileStorageStatus | null;
+  lastError: FileStorageErrorInfo | null;
+  lastSaveTime: number | null;
+  consecutiveFailures: number;
+}
+
+export type FileStorageAction =
+  | { type: 'SERVICE_INITIALIZED'; supported: boolean }
+  | { type: 'SERVICE_RESET' }
+  | { type: 'STATUS_CHANGED'; status: FileStorageStatus }
+  | { type: 'CONNECT_REQUESTED' }
+  | { type: 'CONNECT_COMPLETED' }
+  | { type: 'CONNECT_CONFIRMED' }
+  | { type: 'PERMISSION_DENIED' }
+  | { type: 'DISCONNECTED' }
+  | { type: 'ERROR_REPORTED'; error: FileStorageErrorInfo };
+
+export const initialMachineState: FileStorageMachineState = {
+  lifecycle: 'uninitialized',
+  permissionStatus: 'unknown',
+  isSupported: undefined,
+  hasStoredHandle: false,
+  isConnected: false,
+  explicitlyConnected: false,
+  statusSnapshot: null,
+  lastError: null,
+  lastSaveTime: null,
+  consecutiveFailures: 0,
+};
+
+function normalizePermissionStatus(permission: string | undefined): FileStoragePermissionState {
+  if (permission === 'granted' || permission === 'denied' || permission === 'prompt') {
+    return permission;
+  }
+  return 'unknown';
+}
+
+function computeHasStoredHandle(status: FileStorageStatus, permissionStatus: FileStoragePermissionState): boolean {
+  if (status.status === 'disconnected') {
+    return false;
+  }
+
+  return permissionStatus === 'granted' || permissionStatus === 'prompt';
+}
+
+function deriveLifecycle(
+  baseState: FileStorageMachineState,
+  status: FileStorageStatus,
+  permissionStatus: FileStoragePermissionState,
+): FileStorageLifecycleState {
+  if (baseState.isSupported === false) {
+    return 'unsupported';
+  }
+
+  switch (status.status) {
+    case 'initialized':
+    case 'stopped':
+      return baseState.explicitlyConnected && permissionStatus === 'granted' ? 'ready' : 'idle';
+    case 'connected':
+      return 'ready';
+    case 'running':
+      return baseState.explicitlyConnected && permissionStatus === 'granted'
+        ? 'ready'
+        : baseState.lifecycle === 'requestingPermission'
+          ? 'requestingPermission'
+          : 'idle';
+    case 'waiting':
+      if (permissionStatus === 'denied') {
+        return 'blocked';
+      }
+      return baseState.explicitlyConnected && permissionStatus === 'granted' ? 'ready' : 'idle';
+    case 'retrying':
+      return 'recovering';
+    case 'disconnected':
+      return 'idle';
+    case 'error':
+      return 'error';
+    default:
+      return baseState.lifecycle;
+  }
+}
+
+export function reduceFileStorageState(state: FileStorageMachineState, action: FileStorageAction): FileStorageMachineState {
+  switch (action.type) {
+    case 'SERVICE_INITIALIZED':
+      if (!action.supported) {
+        return { ...state, lifecycle: 'unsupported', isSupported: false };
+      }
+      return {
+        ...state,
+        lifecycle: state.lifecycle === 'uninitialized' ? 'idle' : state.lifecycle,
+        isSupported: true,
+      };
+    case 'SERVICE_RESET':
+      return {
+        ...initialMachineState,
+        isSupported: state.isSupported,
+      };
+    case 'CONNECT_REQUESTED':
+      return { ...state, lifecycle: 'requestingPermission' };
+    case 'CONNECT_CONFIRMED':
+      return {
+        ...state,
+        explicitlyConnected: true,
+        isConnected: state.permissionStatus === 'granted' ? true : state.isConnected,
+      };
+    case 'CONNECT_COMPLETED':
+      if (state.explicitlyConnected) {
+        return state;
+      }
+      return {
+        ...state,
+        lifecycle: state.lifecycle === 'requestingPermission' ? 'idle' : state.lifecycle,
+      };
+    case 'PERMISSION_DENIED':
+      return {
+        ...state,
+        lifecycle: 'blocked',
+        permissionStatus: 'denied',
+        explicitlyConnected: false,
+        isConnected: false,
+        hasStoredHandle: false,
+      };
+    case 'DISCONNECTED':
+      return {
+        ...state,
+        lifecycle: 'idle',
+        explicitlyConnected: false,
+        isConnected: false,
+        hasStoredHandle: false,
+      };
+    case 'ERROR_REPORTED':
+      return {
+        ...state,
+        lastError: action.error,
+        lifecycle: action.error.type === 'warning' ? state.lifecycle : 'error',
+      };
+    case 'STATUS_CHANGED': {
+      const permissionStatus = normalizePermissionStatus(action.status.permissionStatus);
+      const hasStoredHandle = computeHasStoredHandle(action.status, permissionStatus);
+
+      let explicitlyConnected = state.explicitlyConnected;
+      let isConnected = state.isConnected;
+
+      if (permissionStatus === 'denied' || action.status.status === 'disconnected') {
+        explicitlyConnected = false;
+        isConnected = false;
+      } else if (explicitlyConnected) {
+        isConnected =
+          permissionStatus === 'granted' &&
+          action.status.status !== 'disconnected' &&
+          action.status.status !== 'error';
+      }
+
+      const baseState: FileStorageMachineState = {
+        ...state,
+        explicitlyConnected,
+        hasStoredHandle,
+      };
+
+      const lifecycle = deriveLifecycle(baseState, action.status, permissionStatus);
+
+      const nextState: FileStorageMachineState = {
+        ...baseState,
+        lifecycle,
+        permissionStatus,
+        isConnected,
+        statusSnapshot: action.status,
+        lastSaveTime: action.status.lastSaveTime ?? null,
+        consecutiveFailures: action.status.consecutiveFailures ?? 0,
+      };
+
+      if (action.status.status !== 'error' && state.lastError) {
+        nextState.lastError = null;
+      }
+
+      return nextState;
+    }
+    default:
+      return state;
+  }
+}
+
+export const readyLifecycleStates: ReadonlySet<FileStorageLifecycleState> = new Set(['ready', 'saving']);
+export const blockingLifecycleStates: ReadonlySet<FileStorageLifecycleState> = new Set(['blocked', 'error']);

--- a/docs/development/progression-strategy.md
+++ b/docs/development/progression-strategy.md
@@ -28,10 +28,11 @@ This plan realigns the roadmap around those themes while preserving the filesyst
 ### Phase 3 · File-Storage Experience (In Progress)
 
 #### Subphase 3.1 · Storage State Machine
-- Replace the remaining `window.*` coordination flags with a reducer-backed state machine owned by `FileStorageContext`.
-- Model the full permission lifecycle (`idle → requesting → ready → blocked`, including `recovering` and `error` branches) so UI consumers can subscribe to stable selectors.
-- Update hooks (`useConnectionFlow`, `useNavigationFlow`, autosave helpers) to consume the typed state instead of ad-hoc booleans.
-- Deliverables: context reducer + action map, TypeScript definitions for storage states, regression tests covering grant/deny/revoke scenarios.
+- ✅ Replace the remaining `window.*` coordination flags with a reducer-backed state machine owned by `FileStorageContext`.
+- ✅ Model the full permission lifecycle (`idle → requesting → ready → blocked`, including `recovering` and `error` branches) so UI consumers can subscribe to stable selectors via `useFileStorageLifecycleSelectors`.
+- ✅ Update hooks (`useConnectionFlow`, `useImportListeners`) to consume the typed state instead of ad-hoc booleans; propagate lifecycle-aware messaging through `useAppContentViewModel`.
+- 🚧 Planned: extend navigation and additional autosave helpers once lifecycle telemetry drives UI decisions.
+- Deliverables: context reducer + action map, TypeScript definitions for storage states, regression tests covering grant/deny/revoke scenarios (**completed**).
 
 **State schema draft**
 - **States**

--- a/docs/development/progression-strategy.md
+++ b/docs/development/progression-strategy.md
@@ -30,8 +30,8 @@ This plan realigns the roadmap around those themes while preserving the filesyst
 #### Subphase 3.1 · Storage State Machine
 - ✅ Replace the remaining `window.*` coordination flags with a reducer-backed state machine owned by `FileStorageContext`.
 - ✅ Model the full permission lifecycle (`idle → requesting → ready → blocked`, including `recovering` and `error` branches) so UI consumers can subscribe to stable selectors via `useFileStorageLifecycleSelectors`.
-- ✅ Update hooks (`useConnectionFlow`, `useImportListeners`) to consume the typed state instead of ad-hoc booleans; propagate lifecycle-aware messaging through `useAppContentViewModel`.
-- 🚧 Planned: extend navigation and additional autosave helpers once lifecycle telemetry drives UI decisions.
+- ✅ Update hooks (`useConnectionFlow`, `useNavigationFlow`, `useImportListeners`) to consume the typed state instead of ad-hoc booleans; propagate lifecycle-aware messaging through `useAppContentViewModel` and gate case interactions on lifecycle locks.
+- 🚧 Planned: extend autosave helpers once lifecycle telemetry drives UI decisions.
 - Deliverables: context reducer + action map, TypeScript definitions for storage states, regression tests covering grant/deny/revoke scenarios (**completed**).
 
 **State schema draft**

--- a/hooks/__tests__/useNavigationFlow.test.ts
+++ b/hooks/__tests__/useNavigationFlow.test.ts
@@ -1,0 +1,173 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useNavigationFlow } from "../useNavigationFlow";
+import type { FileStorageLifecycleSelectors } from "../../contexts/FileStorageContext";
+import type { CaseDisplay } from "../../types/case";
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+const sampleCase: CaseDisplay = {
+  id: "case-1",
+  name: "Sample Case",
+  mcn: "MCN-1",
+  status: "In Progress",
+  priority: false,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  person: {
+    id: "person-1",
+    firstName: "Jane",
+    lastName: "Doe",
+    name: "Jane Doe",
+    email: "jane@example.com",
+    phone: "555-123-4567",
+    dateOfBirth: "1990-01-01",
+    ssn: "123-45-6789",
+    organizationId: null,
+    livingArrangement: "Home",
+    address: {
+      street: "1 Main St",
+      city: "Springfield",
+      state: "IL",
+      zip: "62704",
+    },
+    mailingAddress: {
+      street: "1 Main St",
+      city: "Springfield",
+      state: "IL",
+      zip: "62704",
+      sameAsPhysical: true,
+    },
+    authorizedRepIds: [],
+    familyMembers: [],
+    status: "Active",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    dateAdded: "2024-01-01T00:00:00.000Z",
+  },
+  caseRecord: {
+    id: "record-1",
+    mcn: "MCN-1",
+    applicationDate: "2024-01-05",
+    caseType: "General",
+    personId: "person-1",
+    spouseId: "",
+    status: "In Progress",
+    description: "Initial case",
+    priority: false,
+    livingArrangement: "Home",
+    withWaiver: false,
+    admissionDate: "2024-01-10",
+    organizationId: "org-1",
+    authorizedReps: [],
+    retroRequested: "No",
+    financials: {
+      resources: [],
+      income: [],
+      expenses: [],
+    },
+    notes: [],
+    createdDate: "2024-01-01T00:00:00.000Z",
+    updatedDate: "2024-01-01T00:00:00.000Z",
+  },
+};
+
+const readyConnectionState: FileStorageLifecycleSelectors = {
+  lifecycle: "ready",
+  permissionStatus: "granted",
+  isReady: true,
+  isBlocked: false,
+  isErrored: false,
+  isRecovering: false,
+  isAwaitingUserChoice: false,
+  hasStoredHandle: true,
+  isConnected: true,
+  lastError: null,
+};
+
+const blockedConnectionState: FileStorageLifecycleSelectors = {
+  lifecycle: "blocked",
+  permissionStatus: "denied",
+  isReady: false,
+  isBlocked: true,
+  isErrored: false,
+  isRecovering: false,
+  isAwaitingUserChoice: false,
+  hasStoredHandle: true,
+  isConnected: false,
+  lastError: {
+    message: "Permission denied",
+    timestamp: Date.now(),
+  },
+};
+
+describe("useNavigationFlow", () => {
+  const cases = [sampleCase];
+  const saveCase = vi.fn().mockResolvedValue(undefined);
+  const deleteCase = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows navigation when storage is ready", () => {
+    const { result } = renderHook(() =>
+      useNavigationFlow({ cases, connectionState: readyConnectionState, saveCase, deleteCase }),
+    );
+
+    act(() => {
+      result.current.navigate("list");
+    });
+
+    expect(result.current.currentView).toBe("list");
+    expect(result.current.navigationLock.locked).toBe(false);
+  });
+
+  it("locks case navigation when storage becomes blocked and restores previous view when ready", async () => {
+    const { result, rerender } = renderHook(
+      ({ connectionState }: { connectionState: FileStorageLifecycleSelectors }) =>
+        useNavigationFlow({ cases, connectionState, saveCase, deleteCase }),
+      {
+        initialProps: { connectionState: readyConnectionState },
+      },
+    );
+
+    act(() => {
+      result.current.navigate("list");
+    });
+
+    expect(result.current.currentView).toBe("list");
+
+    await act(async () => {
+      rerender({ connectionState: blockedConnectionState });
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentView).toBe("settings");
+    });
+
+    act(() => {
+      result.current.viewCase(sampleCase.id);
+    });
+
+    expect(result.current.currentView).toBe("settings");
+    expect(result.current.selectedCaseId).toBeNull();
+    expect(result.current.navigationLock.locked).toBe(true);
+
+    await act(async () => {
+      rerender({ connectionState: readyConnectionState });
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentView).toBe("list");
+    });
+    expect(result.current.navigationLock.locked).toBe(false);
+  });
+});

--- a/hooks/useImportListeners.ts
+++ b/hooks/useImportListeners.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 interface UseImportListenersParams {
   loadCases: () => Promise<unknown>;
   setError: React.Dispatch<React.SetStateAction<string | null>>;
+  isStorageReady: boolean;
 }
 
 /**
@@ -14,11 +15,15 @@ interface UseImportListenersParams {
  * - Surface import errors consistently via toast + error banner
  * - Automatically cleans up listeners on unmount
  */
-export function useImportListeners({ loadCases, setError }: UseImportListenersParams) {
+export function useImportListeners({ loadCases, setError, isStorageReady }: UseImportListenersParams) {
   useEffect(() => {
     const handleFileImported = () => {
       // Skip automatic reloads during the connect-to-existing flow
       if (window.location.hash === "#connect-to-existing") {
+        return;
+      }
+
+      if (!isStorageReady) {
         return;
       }
 
@@ -45,5 +50,5 @@ export function useImportListeners({ loadCases, setError }: UseImportListenersPa
       window.removeEventListener("fileDataImported", handleFileImported);
       window.removeEventListener("fileImportError", handleFileImportError as EventListener);
     };
-  }, [loadCases, setError]);
+  }, [isStorageReady, loadCases, setError]);
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -35,7 +35,6 @@ declare global {
   interface Window {
     showDirectoryPicker(): Promise<FileSystemDirectoryHandle>;
     handleFileDataLoaded?: (fileData: unknown) => void;
-    fileStorageNotifyChange?: () => void;
   }
 
   var NightingaleFileService: unknown;


### PR DESCRIPTION
Teaching [useNavigationFlow](https://super-fishstick-x54xx7xvpr9jfpgvr.github.dev/) about the file-storage lifecycle: it now memoizes a navigation lock, redirects locked views to settings, guards case interactions, and surfaces contextual toasts while remembering the user’s prior view.
Threaded the new lifecycle selectors through [App.tsx](https://super-fishstick-x54xx7xvpr9jfpgvr.github.dev/) and tightened component state (sidebar, breadcrumbs) so the UI stays consistent with lock/unlock transitions.
Added a focused test suite in [useNavigationFlow.test.ts](https://super-fishstick-x54xx7xvpr9jfpgvr.github.dev/) and refined the connection flow integration test to wait for the service to report connected, aligning expectations with the new gating.
Documented the Subphase 3.1 milestone in [progression-strategy.md](https://super-fishstick-x54xx7xvpr9jfpgvr.github.dev/) and made [FileStorageSettings](https://super-fishstick-x54xx7xvpr9jfpgvr.github.dev/) resilient to missing [consecutiveFailures](https://super-fishstick-x54xx7xvpr9jfpgvr.github.dev/) data.
tests
npm run test:run
npm run build