### PR TITLE
Fix/timestamp touch control

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -51,6 +51,7 @@ const AppContent = memo(function AppContent() {
     loadCases,
     saveCase,
     deleteCase,
+    updateCaseStatus,
     setCases,
     setError,
     setHasLoadedData,
@@ -251,6 +252,11 @@ const AppContent = memo(function AppContent() {
     setCases(prevCases => prevCases.map(c => (c.id === updatedCase.id ? updatedCase : c)));
   }, [setCases]);
 
+  const handleUpdateCaseStatus = useCallback(
+    (caseId: string, status: CaseDisplay["status"]) => updateCaseStatus(caseId, status),
+    [updateCaseStatus],
+  );
+
   const handleDismissError = useCallback(() => {
     setError(null);
   }, [setError]);
@@ -389,6 +395,7 @@ const AppContent = memo(function AppContent() {
       financialFlow,
       noteFlow,
       alerts: alertsIndex,
+      onUpdateCaseStatus: handleUpdateCaseStatus,
     }),
     [
       cases,
@@ -396,6 +403,7 @@ const AppContent = memo(function AppContent() {
       error,
       financialFlow,
       handleDismissError,
+      handleUpdateCaseStatus,
       noteFlow,
       selectedCase,
       viewHandlers,

--- a/__tests__/DataManager.test.ts
+++ b/__tests__/DataManager.test.ts
@@ -354,6 +354,56 @@ describe('DataManager', () => {
     })
   })
 
+  describe('timestamp control', () => {
+    it('updates updatedAt only for cases that were modified', async () => {
+      const originalTimestamp = '2024-01-01T00:00:00.000Z'
+      const untouchedTimestamp = '2023-12-15T12:00:00.000Z'
+      const targetCase = createMockCaseDisplay({ id: 'case-target', updatedAt: originalTimestamp })
+      const untouchedCase = createMockCaseDisplay({ id: 'case-untouched', updatedAt: untouchedTimestamp })
+
+      mockAutosaveService.readFile.mockResolvedValue(createFileData({
+        cases: [targetCase, untouchedCase],
+        total_cases: 2,
+      }))
+
+      let capturedPayload: any
+      mockAutosaveService.writeFile.mockImplementation(async (data: any) => {
+        capturedPayload = data
+        return true
+      })
+
+      const result = await dataManager.updateCompleteCase('case-target', {
+        person: { ...targetCase.person, firstName: 'Casey' },
+        caseRecord: targetCase.caseRecord,
+      })
+
+      expect(result.updatedAt).not.toBe(originalTimestamp)
+      expect(capturedPayload.cases.find((c: any) => c.id === 'case-target').updatedAt).toBe(result.updatedAt)
+      expect(capturedPayload.cases.find((c: any) => c.id === 'case-untouched').updatedAt).toBe(untouchedTimestamp)
+    })
+
+    it('preserves updatedAt during passive writes', async () => {
+      const originalTimestamp = '2024-02-02T08:00:00.000Z'
+      const existingCase = createMockCaseDisplay({ id: 'case-passive', updatedAt: originalTimestamp })
+
+      mockAutosaveService.readFile.mockResolvedValue(createFileData({
+        cases: [existingCase],
+        total_cases: 1,
+      }))
+
+      let capturedPayload: any
+      mockAutosaveService.writeFile.mockImplementation(async (data: any) => {
+        capturedPayload = data
+        return true
+      })
+
+      const updatedConfig = mergeCategoryConfig({ caseTypes: ['Passive Update'] })
+      await dataManager.updateCategoryConfig(updatedConfig)
+
+      expect(capturedPayload.cases[0].updatedAt).toBe(originalTimestamp)
+    })
+  })
+
   describe('category configuration', () => {
     it('merges missing category values when retrieving config', async () => {
       const partialConfig = {

--- a/components/__tests__/CaseDetails.test.tsx
+++ b/components/__tests__/CaseDetails.test.tsx
@@ -162,6 +162,7 @@ const mockProps = {
   onAddNote: vi.fn(),
   onEditNote: vi.fn(),
   onDeleteNote: vi.fn(),
+  onUpdateStatus: vi.fn(),
 };
 
 describe('CaseDetails Memory Management', () => {

--- a/components/app/CaseWorkspace.tsx
+++ b/components/app/CaseWorkspace.tsx
@@ -70,6 +70,7 @@ export interface CaseWorkspaceProps {
   financialFlow: CaseWorkspaceFinancialFlow;
   noteFlow: CaseWorkspaceNoteFlow;
   alerts: AlertsIndex;
+  onUpdateCaseStatus: (caseId: string, status: CaseDisplay["status"]) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
 }
 
 /**
@@ -88,6 +89,7 @@ export const CaseWorkspace = memo(function CaseWorkspace({
   financialFlow,
   noteFlow,
   alerts,
+  onUpdateCaseStatus,
 }: CaseWorkspaceProps) {
   return (
     <AppNavigationShell {...navigation}>
@@ -126,6 +128,7 @@ export const CaseWorkspace = memo(function CaseWorkspace({
         handleDeleteNote={noteFlow.handleDeleteNote}
         handleBatchUpdateNote={noteFlow.handleBatchUpdateNote}
         handleBatchCreateNote={noteFlow.handleBatchCreateNote}
+        handleUpdateCaseStatus={onUpdateCaseStatus}
       />
 
       {financialFlow.itemForm.isOpen && financialFlow.itemForm.category && selectedCase && (

--- a/components/case/CaseDetails.tsx
+++ b/components/case/CaseDetails.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { Button } from "../ui/button";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "../ui/alert-dialog";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "../ui/resizable";
@@ -28,6 +29,10 @@ interface CaseDetailsProps {
   onBatchUpdateNote?: (noteId: string, updatedNote: NewNoteData) => Promise<void>;
   onBatchCreateNote?: (noteData: NewNoteData) => Promise<void>;
   alerts?: AlertWithMatch[];
+  onUpdateStatus?: (
+    caseId: string,
+    status: CaseDisplay["status"],
+  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
 }
 
 export function CaseDetails({ 
@@ -45,6 +50,7 @@ export function CaseDetails({
   onBatchUpdateNote,
   onBatchCreateNote,
   alerts = [],
+  onUpdateStatus,
 }: CaseDetailsProps) {
   
   // Handle batched update for inline editing
@@ -60,6 +66,14 @@ export function CaseDetails({
   };
 
   const totalAlerts = alerts.length;
+
+  const handleStatusChange = useCallback(
+    (status: CaseDisplay["status"]) => {
+      if (!onUpdateStatus) return;
+      onUpdateStatus(caseData.id, status);
+    },
+    [caseData.id, onUpdateStatus],
+  );
 
   return (
     <div className="space-y-6">
@@ -81,7 +95,10 @@ export function CaseDetails({
                 <h1 className="text-xl font-bold text-foreground">
                   {caseData.name || 'Unnamed Case'}
                 </h1>
-                <CaseStatusBadge status={caseData.status} />
+                <CaseStatusBadge
+                  status={caseData.status}
+                  onStatusChange={onUpdateStatus ? handleStatusChange : undefined}
+                />
               </div>
               <div className="flex items-center gap-2 text-muted-foreground">
                 <span className="text-sm font-medium">MCN:</span>

--- a/components/routing/ViewRenderer.tsx
+++ b/components/routing/ViewRenderer.tsx
@@ -41,6 +41,11 @@ interface ViewRendererProps {
   handleDeleteNote: (noteId: string) => Promise<void>;
   handleBatchUpdateNote?: (noteId: string, updatedNote: any) => Promise<void>;
   handleBatchCreateNote?: (noteData: any) => Promise<void>;
+  handleUpdateCaseStatus?: (caseId: string, status: CaseDisplay["status"]) =>
+    | Promise<CaseDisplay | null>
+    | CaseDisplay
+    | null
+    | void;
 }
 
 /**
@@ -85,7 +90,8 @@ export function ViewRenderer({
   handleEditNote,
   handleDeleteNote,
   handleBatchUpdateNote,
-  handleBatchCreateNote
+  handleBatchCreateNote,
+  handleUpdateCaseStatus,
 }: ViewRendererProps) {
   
   switch (currentView) {
@@ -137,6 +143,7 @@ export function ViewRenderer({
           onDeleteNote={handleDeleteNote}
           onBatchUpdateNote={handleBatchUpdateNote}
           onBatchCreateNote={handleBatchCreateNote}
+          onUpdateStatus={handleUpdateCaseStatus}
         />
       ) : (
         <div className="text-center p-8">Case not found</div>

--- a/utils/DataManager.ts
+++ b/utils/DataManager.ts
@@ -236,15 +236,12 @@ export class DataManager {
   private async writeFileData(data: FileData): Promise<FileData> {
     try {
       // Ensure data integrity before writing
-      const validatedData = {
+      const validatedData: FileData = {
         ...data,
         exported_at: new Date().toISOString(),
         total_cases: data.cases.length,
         categoryConfig: mergeCategoryConfig(data.categoryConfig),
-        cases: data.cases.map(caseItem => ({
-          ...caseItem,
-          updatedAt: new Date().toISOString()
-        }))
+        cases: data.cases.map(caseItem => ({ ...caseItem })),
       };
 
       const success = await this.fileService.writeFile(validatedData);
@@ -277,6 +274,28 @@ export class DataManager {
 
       throw new Error(`Failed to save case data: ${errorMessage}`);
     }
+  }
+
+  private touchCaseTimestamps(
+    cases: CaseDisplay[],
+    touchedCaseIds?: Iterable<string>,
+  ): CaseDisplay[] {
+    if (!touchedCaseIds) {
+      return cases;
+    }
+
+    const ids = touchedCaseIds instanceof Set ? touchedCaseIds : new Set(touchedCaseIds);
+    if (ids.size === 0) {
+      return cases;
+    }
+
+    const timestamp = new Date().toISOString();
+
+    return cases.map(caseItem => (
+      ids.has(caseItem.id)
+        ? { ...caseItem, updatedAt: timestamp }
+        : caseItem
+    ));
   }
 
   // =============================================================================
@@ -445,15 +464,18 @@ export class DataManager {
     newCase.caseRecord.personId = newCase.person.id;
 
     // Modify data
+    const casesWithNewCase = [...currentData.cases, newCase];
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(casesWithNewCase, [newCase.id]);
+
     const updatedData: FileData = {
       ...currentData,
-      cases: [...currentData.cases, newCase]
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file
     await this.writeFileData(updatedData);
 
-    return newCase;
+    return casesWithTouchedTimestamps.find(c => c.id === newCase.id) ?? newCase;
   }
 
   /**
@@ -516,29 +538,32 @@ export class DataManager {
       updatedDate: new Date().toISOString()
     };
 
-    const updatedCase: CaseDisplay = {
+    const caseWithChanges: CaseDisplay = {
       ...existingCase,
       name: updatedPerson.name,
       mcn: updatedCaseRecord.mcn,
       status: updatedCaseRecord.status,
       priority: updatedCaseRecord.priority,
-      updatedAt: new Date().toISOString(),
       person: updatedPerson,
-      caseRecord: updatedCaseRecord
+      caseRecord: updatedCaseRecord,
     };
+
+    const casesWithChanges = currentData.cases.map((c, index) =>
+      index === caseIndex ? caseWithChanges : c,
+    );
+
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(casesWithChanges, [caseId]);
 
     // Modify data
     const updatedData: FileData = {
       ...currentData,
-      cases: currentData.cases.map((c, index) => 
-        index === caseIndex ? updatedCase : c
-      )
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file
     await this.writeFileData(updatedData);
 
-    return updatedCase;
+    return casesWithTouchedTimestamps[caseIndex];
   }
 
   /**
@@ -601,31 +626,34 @@ export class DataManager {
     };
 
     // Modify case data
-    const updatedCase: CaseDisplay = {
+    const caseWithNewItem: CaseDisplay = {
       ...targetCase,
-      updatedAt: new Date().toISOString(),
       caseRecord: {
         ...targetCase.caseRecord,
         financials: {
           ...targetCase.caseRecord.financials,
-          [category]: [...targetCase.caseRecord.financials[category], newItem]
+          [category]: [...targetCase.caseRecord.financials[category], newItem],
         },
-        updatedDate: new Date().toISOString()
-      }
+        updatedDate: new Date().toISOString(),
+      },
     };
+
+    const casesWithChanges = currentData.cases.map((c, index) =>
+      index === caseIndex ? caseWithNewItem : c,
+    );
+
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(casesWithChanges, [caseId]);
 
     // Update data
     const updatedData: FileData = {
       ...currentData,
-      cases: currentData.cases.map((c, index) => 
-        index === caseIndex ? updatedCase : c
-      )
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file
     await this.writeFileData(updatedData);
 
-    return updatedCase;
+    return casesWithTouchedTimestamps[caseIndex];
   }
 
   /**
@@ -670,33 +698,36 @@ export class DataManager {
     };
 
     // Modify case data
-    const updatedCase: CaseDisplay = {
+    const caseWithUpdatedItem: CaseDisplay = {
       ...targetCase,
-      updatedAt: new Date().toISOString(),
       caseRecord: {
         ...targetCase.caseRecord,
         financials: {
           ...targetCase.caseRecord.financials,
           [category]: targetCase.caseRecord.financials[category].map((item, index) =>
-            index === itemIndex ? updatedItemData : item
-          )
+            index === itemIndex ? updatedItemData : item,
+          ),
         },
-        updatedDate: new Date().toISOString()
-      }
+        updatedDate: new Date().toISOString(),
+      },
     };
+
+    const casesWithChanges = currentData.cases.map((c, index) =>
+      index === caseIndex ? caseWithUpdatedItem : c,
+    );
+
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(casesWithChanges, [caseId]);
 
     // Update data
     const updatedData: FileData = {
       ...currentData,
-      cases: currentData.cases.map((c, index) => 
-        index === caseIndex ? updatedCase : c
-      )
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file
     await this.writeFileData(updatedData);
 
-    return updatedCase;
+    return casesWithTouchedTimestamps[caseIndex];
   }
 
   /**
@@ -725,31 +756,34 @@ export class DataManager {
     }
 
     // Modify case data
-    const updatedCase: CaseDisplay = {
+    const caseWithItemRemoved: CaseDisplay = {
       ...targetCase,
-      updatedAt: new Date().toISOString(),
       caseRecord: {
         ...targetCase.caseRecord,
         financials: {
           ...targetCase.caseRecord.financials,
-          [category]: targetCase.caseRecord.financials[category].filter(item => item.id !== itemId)
+          [category]: targetCase.caseRecord.financials[category].filter(item => item.id !== itemId),
         },
-        updatedDate: new Date().toISOString()
-      }
+        updatedDate: new Date().toISOString(),
+      },
     };
+
+    const casesWithChanges = currentData.cases.map((c, index) =>
+      index === caseIndex ? caseWithItemRemoved : c,
+    );
+
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(casesWithChanges, [caseId]);
 
     // Update data
     const updatedData: FileData = {
       ...currentData,
-      cases: currentData.cases.map((c, index) => 
-        index === caseIndex ? updatedCase : c
-      )
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file
     await this.writeFileData(updatedData);
 
-    return updatedCase;
+    return casesWithTouchedTimestamps[caseIndex];
   }
 
   // =============================================================================
@@ -785,28 +819,31 @@ export class DataManager {
     };
 
     // Modify case data
-    const updatedCase: CaseDisplay = {
+    const caseWithNewNote: CaseDisplay = {
       ...targetCase,
-      updatedAt: new Date().toISOString(),
       caseRecord: {
         ...targetCase.caseRecord,
         notes: [...(targetCase.caseRecord.notes || []), newNote],
-        updatedDate: new Date().toISOString()
-      }
+        updatedDate: new Date().toISOString(),
+      },
     };
+
+    const casesWithChanges = currentData.cases.map((c, index) =>
+      index === caseIndex ? caseWithNewNote : c,
+    );
+
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(casesWithChanges, [caseId]);
 
     // Update data
     const updatedData: FileData = {
       ...currentData,
-      cases: currentData.cases.map((c, index) => 
-        index === caseIndex ? updatedCase : c
-      )
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file
     await this.writeFileData(updatedData);
 
-    return updatedCase;
+    return casesWithTouchedTimestamps[caseIndex];
   }
 
   /**
@@ -845,30 +882,33 @@ export class DataManager {
     };
 
     // Modify case data
-    const updatedCase: CaseDisplay = {
+    const caseWithUpdatedNote: CaseDisplay = {
       ...targetCase,
-      updatedAt: new Date().toISOString(),
       caseRecord: {
         ...targetCase.caseRecord,
         notes: (targetCase.caseRecord.notes || []).map((note, index) =>
-          index === noteIndex ? updatedNote : note
+          index === noteIndex ? updatedNote : note,
         ),
-        updatedDate: new Date().toISOString()
-      }
+        updatedDate: new Date().toISOString(),
+      },
     };
+
+    const casesWithChanges = currentData.cases.map((c, index) =>
+      index === caseIndex ? caseWithUpdatedNote : c,
+    );
+
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(casesWithChanges, [caseId]);
 
     // Update data
     const updatedData: FileData = {
       ...currentData,
-      cases: currentData.cases.map((c, index) => 
-        index === caseIndex ? updatedCase : c
-      )
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file
     await this.writeFileData(updatedData);
 
-    return updatedCase;
+    return casesWithTouchedTimestamps[caseIndex];
   }
 
   /**
@@ -897,28 +937,31 @@ export class DataManager {
     }
 
     // Modify case data
-    const updatedCase: CaseDisplay = {
+    const caseWithNoteRemoved: CaseDisplay = {
       ...targetCase,
-      updatedAt: new Date().toISOString(),
       caseRecord: {
         ...targetCase.caseRecord,
         notes: (targetCase.caseRecord.notes || []).filter(note => note.id !== noteId),
-        updatedDate: new Date().toISOString()
-      }
+        updatedDate: new Date().toISOString(),
+      },
     };
+
+    const casesWithChanges = currentData.cases.map((c, index) =>
+      index === caseIndex ? caseWithNoteRemoved : c,
+    );
+
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(casesWithChanges, [caseId]);
 
     // Update data
     const updatedData: FileData = {
       ...currentData,
-      cases: currentData.cases.map((c, index) => 
-        index === caseIndex ? updatedCase : c
-      )
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file
     await this.writeFileData(updatedData);
 
-    return updatedCase;
+    return casesWithTouchedTimestamps[caseIndex];
   }
 
   // =============================================================================
@@ -937,20 +980,24 @@ export class DataManager {
     }
 
     // Validate and ensure unique IDs
-    const validatedCases = cases.map(caseItem => ({
+    const casesToImport = cases.map(caseItem => ({
       ...caseItem,
       id: caseItem.id || uuidv4(),
-      updatedAt: new Date().toISOString(),
       caseRecord: {
         ...caseItem.caseRecord,
-        updatedDate: new Date().toISOString()
-      }
+        updatedDate: new Date().toISOString(),
+      },
     }));
+
+    const touchedCaseIds = casesToImport.map(caseItem => caseItem.id);
+
+    const combinedCases = [...currentData.cases, ...casesToImport];
+    const casesWithTouchedTimestamps = this.touchCaseTimestamps(combinedCases, touchedCaseIds);
 
     // Modify data (append new cases)
     const updatedData: FileData = {
       ...currentData,
-      cases: [...currentData.cases, ...validatedCases]
+      cases: casesWithTouchedTimestamps,
     };
 
     // Write back to file


### PR DESCRIPTION
Broadened the status update callback type in CaseWorkspace
ViewRenderer, and CaseDetails so it accepts the Promise<CaseDisplay | null> returned by useCaseManagement.
Matched CaseStatusBadge’s onStatusChange type to the same contract so dropdown interactions remain type-safe end-to-end.
quality gates
npm run build → PASS
npm run test -- --run → PASS (89 tests)
requirements coverage
Fix type mismatch when threading updateCaseStatus through the view model → Done (updated handler types and validated with build/tests).
All set—ping me if you’d like follow-up tweaks or additional coverage.