### PR TITLE
Ensure alert resolution uses canonical storage key

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,7 +18,13 @@ import { AppContentView } from "./components/app/AppContentView";
 import { useAppContentViewModel } from "./components/app/useAppContentViewModel";
 import { clearFileStorageFlags, updateFileStorageFlags } from "./utils/fileStorageFlags";
 import { useCategoryConfig } from "./contexts/CategoryConfigContext";
-import { createAlertsIndexFromAlerts, createEmptyAlertsIndex, type AlertWithMatch, type AlertsIndex } from "./utils/alertsData";
+import {
+  createAlertsIndexFromAlerts,
+  createEmptyAlertsIndex,
+  buildAlertStorageKey,
+  type AlertWithMatch,
+  type AlertsIndex,
+} from "./utils/alertsData";
 import { ENABLE_SAMPLE_ALERTS } from "./utils/featureFlags";
 import { createLogger } from "./utils/logger";
 
@@ -332,8 +338,9 @@ const AppContent = memo(function AppContent() {
       setAlertsIndex(prevIndex => applyAlertOverrides(prevIndex));
 
       try {
+        const identifier = buildAlertStorageKey(alert) ?? alert.id;
         await dataManager.updateAlertStatus(
-          alert.id,
+          identifier,
           {
             status: "resolved",
             resolvedAt,

--- a/__tests__/App.alertResolution.test.tsx
+++ b/__tests__/App.alertResolution.test.tsx
@@ -1,0 +1,315 @@
+import React from "react";
+import { render, act, waitFor, cleanup } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AlertWithMatch } from "@/utils/alertsData";
+import { buildAlertStorageKey, createEmptyAlertsIndex } from "@/utils/alertsData";
+import type { CaseDisplay } from "@/types/case";
+
+let dataManagerMock: any = {};
+let caseManagementMock: any = {};
+let navigationFlowMock: any = {};
+let connectionFlowMock: any = {};
+let financialItemFlowMock: any = {};
+let noteFlowMock: any = {};
+let importListenersMock: any = vi.fn();
+let capturedViewProps: any = null;
+let setConfigFromFileMock: ReturnType<typeof vi.fn> = vi.fn();
+
+const toastMock = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  loading: vi.fn(() => "toast-id"),
+}));
+
+const fileStorageMock = {
+  isSupported: true,
+  hasStoredHandle: false,
+  connectToFolder: vi.fn(),
+  connectToExisting: vi.fn(),
+  loadExistingData: vi.fn(),
+  service: null,
+};
+
+const lifecycleSelectorsMock = {
+  permissionStatus: "granted",
+  lifecycle: "ready",
+  isReady: true,
+};
+
+vi.mock("sonner", () => ({
+  toast: toastMock,
+}));
+
+vi.mock("/workspaces/CMSNext/utils/logger.ts", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    lifecycle: vi.fn(),
+  }),
+}));
+
+vi.mock("/workspaces/CMSNext/components/providers/AppProviders.tsx", () => ({
+  AppProviders: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("/workspaces/CMSNext/components/providers/FileStorageIntegrator.tsx", () => ({
+  FileStorageIntegrator: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("/workspaces/CMSNext/components/ui/sonner.tsx", () => ({
+  Toaster: () => <div data-testid="toaster" />,
+}));
+
+vi.mock("/workspaces/CMSNext/components/app/AppContentView.tsx", () => ({
+  AppContentView: (props: any) => {
+    capturedViewProps = props;
+    return <div data-testid="app-content-view" />;
+  },
+}));
+
+vi.mock("/workspaces/CMSNext/components/app/useAppContentViewModel.ts", () => ({
+  useAppContentViewModel: (args: any) => args,
+}));
+
+vi.mock("/workspaces/CMSNext/contexts/CategoryConfigContext.tsx", () => ({
+  useCategoryConfig: () => ({
+    setConfigFromFile: (...args: unknown[]) => setConfigFromFileMock(...args),
+  }),
+}));
+
+vi.mock("/workspaces/CMSNext/contexts/FileStorageContext.tsx", () => ({
+  useFileStorage: () => fileStorageMock,
+  useFileStorageLifecycleSelectors: () => lifecycleSelectorsMock,
+}));
+
+vi.mock("/workspaces/CMSNext/contexts/DataManagerContext.tsx", () => ({
+  useDataManagerSafe: () => dataManagerMock,
+}));
+
+vi.mock("/workspaces/CMSNext/hooks/index.ts", () => ({
+  useCaseManagement: () => caseManagementMock,
+  useConnectionFlow: () => connectionFlowMock,
+  useFinancialItemFlow: () => financialItemFlowMock,
+  useNavigationFlow: () => navigationFlowMock,
+  useNoteFlow: () => noteFlowMock,
+  useImportListeners: (args: unknown) => importListenersMock(args),
+}));
+
+import App from "@/App";
+
+function buildTestCase(): CaseDisplay {
+  const now = new Date().toISOString();
+  return {
+    id: "case-123",
+    name: "Jane Doe",
+    mcn: "MCN12345",
+    status: "Active",
+    priority: false,
+    createdAt: now,
+    updatedAt: now,
+    person: {
+      id: "person-1",
+      firstName: "Jane",
+      lastName: "Doe",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      phone: "555-0000",
+      dateOfBirth: now,
+      ssn: "123-45-6789",
+      organizationId: null,
+      livingArrangement: "",
+      address: { street: "", city: "", state: "", zip: "" },
+      mailingAddress: { street: "", city: "", state: "", zip: "", sameAsPhysical: true },
+      authorizedRepIds: [],
+      familyMembers: [],
+      status: "Active",
+      createdAt: now,
+      dateAdded: now,
+    },
+    caseRecord: {
+      id: "record-1",
+      mcn: "MCN12345",
+      applicationDate: now,
+      caseType: "",
+      personId: "person-1",
+      spouseId: "",
+      status: "Active",
+      description: "",
+      priority: false,
+      livingArrangement: "",
+      withWaiver: false,
+      admissionDate: now,
+      organizationId: "",
+      authorizedReps: [],
+      retroRequested: "",
+      financials: {
+        resources: [],
+        income: [],
+        expenses: [],
+      },
+      notes: [],
+      createdDate: now,
+      updatedDate: now,
+    },
+    alerts: [],
+  };
+}
+
+function buildMatchedAlert(overrides: Partial<AlertWithMatch> = {}): AlertWithMatch {
+  const baseTimestamp = "2024-03-01T00:00:00.000Z";
+  return {
+    id: overrides.id ?? "alert-random-id",
+    reportId: overrides.reportId ?? "report-001",
+    alertCode: overrides.alertCode ?? "AL-101",
+    alertType: overrides.alertType ?? "Recertification",
+    severity: overrides.severity ?? "High",
+    alertDate: overrides.alertDate ?? baseTimestamp,
+    createdAt: overrides.createdAt ?? baseTimestamp,
+    updatedAt: overrides.updatedAt ?? baseTimestamp,
+    mcNumber: overrides.mcNumber ?? "MCN12345",
+    personName: overrides.personName ?? "Jane Doe",
+    program: overrides.program ?? "Medicaid",
+    region: overrides.region ?? "Region 1",
+    state: overrides.state ?? "NC",
+    source: overrides.source ?? "Import",
+    description: overrides.description ?? "Follow up with client",
+    status: overrides.status ?? "new",
+    resolvedAt: overrides.resolvedAt ?? null,
+    resolutionNotes: overrides.resolutionNotes,
+    metadata: overrides.metadata ?? {},
+    matchStatus: overrides.matchStatus ?? "matched",
+    matchedCaseId: overrides.matchedCaseId ?? "case-123",
+    matchedCaseName: overrides.matchedCaseName ?? "Jane Doe",
+    matchedCaseStatus: overrides.matchedCaseStatus ?? "Active",
+  };
+}
+
+describe("App alert resolution", () => {
+  beforeEach(() => {
+  capturedViewProps = null;
+
+    Object.values(toastMock).forEach(mockFn => mockFn.mockClear());
+
+    Object.assign(fileStorageMock, {
+      isSupported: true,
+      hasStoredHandle: false,
+      connectToFolder: vi.fn(),
+      connectToExisting: vi.fn(),
+      loadExistingData: vi.fn(),
+      service: null,
+    });
+
+    dataManagerMock = {
+      updateAlertStatus: vi.fn().mockResolvedValue(undefined),
+      getAlertsIndex: vi.fn().mockResolvedValue(createEmptyAlertsIndex()),
+    };
+
+    const testCase = buildTestCase();
+    caseManagementMock = {
+      cases: [testCase],
+      loading: false,
+      error: null,
+      hasLoadedData: true,
+      loadCases: vi.fn(),
+      saveCase: vi.fn(),
+      deleteCase: vi.fn(),
+      updateCaseStatus: vi.fn(),
+      setCases: vi.fn(),
+      setError: vi.fn(),
+      setHasLoadedData: vi.fn(),
+    };
+
+    navigationFlowMock = {
+      currentView: "case",
+      selectedCase: testCase,
+      editingCase: null,
+      sidebarOpen: false,
+      breadcrumbTitle: "Test Case",
+      navigate: vi.fn(),
+      viewCase: vi.fn(),
+      editCase: vi.fn(),
+      newCase: vi.fn(),
+      saveCaseWithNavigation: vi.fn(),
+      cancelForm: vi.fn(),
+      deleteCaseWithNavigation: vi.fn(),
+      backToList: vi.fn(),
+      setSidebarOpen: vi.fn(),
+      navigationLock: null,
+    };
+
+    connectionFlowMock = {
+      showConnectModal: false,
+      handleChooseNewFolder: vi.fn(),
+      handleConnectToExisting: vi.fn(),
+      dismissConnectModal: vi.fn(),
+    };
+
+    financialItemFlowMock = {
+      itemForm: null,
+      openItemForm: vi.fn(),
+      closeItemForm: vi.fn(),
+      handleDeleteItem: vi.fn(),
+      handleBatchUpdateItem: vi.fn(),
+      handleCreateItem: vi.fn(),
+    };
+
+    noteFlowMock = {
+      noteForm: null,
+      handleAddNote: vi.fn(),
+      handleEditNote: vi.fn(),
+      handleDeleteNote: vi.fn(),
+      handleSaveNote: vi.fn(),
+      handleCancelNoteForm: vi.fn(),
+      handleBatchUpdateNote: vi.fn(),
+      handleBatchCreateNote: vi.fn(),
+    };
+
+    importListenersMock = vi.fn();
+    setConfigFromFileMock = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the canonical alert storage key when resolving alerts", async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(capturedViewProps?.workspaceState?.onResolveAlert).toBeInstanceOf(Function);
+    });
+
+    const alert = buildMatchedAlert({
+      id: "alert-plain-id",
+      reportId: "canonical-report",
+      description: "Client interview scheduled",
+    });
+
+    const expectedKey = buildAlertStorageKey(alert);
+    expect(expectedKey).not.toBeNull();
+    expect(expectedKey).not.toBe(alert.id);
+
+    await act(async () => {
+      await capturedViewProps.workspaceState.onResolveAlert(alert);
+    });
+
+    expect(dataManagerMock.updateAlertStatus).toHaveBeenCalledTimes(1);
+    expect(dataManagerMock.updateAlertStatus).toHaveBeenCalledWith(
+      expectedKey,
+      expect.objectContaining({ status: "resolved" }),
+      { cases: caseManagementMock.cases },
+    );
+
+  expect(dataManagerMock.getAlertsIndex).toHaveBeenCalledTimes(2);
+  const finalGetAlertsCall = dataManagerMock.getAlertsIndex.mock.calls.at(-1);
+  expect(finalGetAlertsCall).toEqual([{ cases: caseManagementMock.cases }]);
+    expect(toastMock.success).toHaveBeenCalledWith(
+      "Alert resolved",
+      expect.objectContaining({ description: expect.stringContaining("Add a note") }),
+    );
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/DataManager.test.ts
+++ b/__tests__/DataManager.test.ts
@@ -627,6 +627,78 @@ describe('DataManager', () => {
       parseStackedSpy.mockRestore()
     })
 
+    it('upgrades stored workflow state when incoming alerts are resolved', async () => {
+      const mockCase = createMockCaseDisplay({
+        id: 'case-resolved-upgrade',
+        mcn: '8888',
+        caseRecord: createMockCaseRecord({ id: 'record-resolved-upgrade', mcn: '8888' })
+      })
+
+      const storedAlert = buildAlert({
+        id: 'alert-resolved-upgrade',
+        reportId: 'alert-resolved-upgrade',
+        mcNumber: '8888',
+        matchedCaseId: 'case-resolved-upgrade',
+        matchStatus: 'matched',
+        status: 'new',
+        resolvedAt: null,
+        updatedAt: '2025-09-20T00:00:00.000Z',
+      })
+
+      mockAutosaveService.readNamedFile.mockResolvedValueOnce({
+        version: 3,
+        generatedAt: '2025-09-20T00:00:00.000Z',
+        summary: {
+          total: 1,
+          matched: 1,
+          unmatched: 0,
+          missingMcn: 0,
+          latestUpdated: '2025-09-20T00:00:00.000Z',
+        },
+        alerts: [storedAlert],
+        uniqueAlerts: 1,
+        sourceFile: 'alerts.csv',
+      })
+
+      const incomingResolved = buildAlert({
+        id: 'alert-resolved-upgrade',
+        reportId: 'alert-resolved-upgrade',
+        mcNumber: '8888',
+        matchedCaseId: 'case-resolved-upgrade',
+        matchStatus: 'matched',
+        status: 'resolved',
+        resolvedAt: '2025-09-25T15:30:00.000Z',
+        resolutionNotes: 'Resolved via import',
+        updatedAt: '2025-09-25T15:30:00.000Z',
+      })
+
+      const parseStackedSpy = vi.spyOn(alertsData, 'parseStackedAlerts').mockReturnValue(
+        alertsData.createAlertsIndexFromAlerts([incomingResolved])
+      )
+
+      const result = await dataManager.mergeAlertsFromCsvContent('csv-updated', {
+        cases: [mockCase],
+        sourceFileName: 'alerts-updated.csv',
+      })
+
+      expect(result.updated).toBe(1)
+
+  const payload = mockAutosaveService.writeNamedFile.mock.calls.at(-1)?.[1] as { alerts?: AlertWithMatch[]; summary?: { total: number } } | undefined
+      expect(payload?.alerts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'alert-resolved-upgrade',
+            status: 'resolved',
+            resolvedAt: '2025-09-25T15:30:00.000Z',
+            resolutionNotes: 'Resolved via import',
+          })
+        ])
+      )
+      expect(payload?.summary?.total).toBe(1)
+
+      parseStackedSpy.mockRestore()
+    })
+
     it('preserves stacked alerts that share reportId but differ by metadata', async () => {
       const csvContent = [
         '"Stacked Alerts Export"',

--- a/utils/DataManager.ts
+++ b/utils/DataManager.ts
@@ -197,6 +197,13 @@ export class DataManager {
     "snoozed",
     "resolved",
   ]);
+  private static readonly ALERT_WORKFLOW_PRIORITY: AlertWorkflowStatus[] = [
+    "new",
+    "in-progress",
+    "acknowledged",
+    "snoozed",
+    "resolved",
+  ];
 
   constructor(config: DataManagerConfig) {
     this.fileService = config.fileService;
@@ -461,15 +468,31 @@ export class DataManager {
 
     const metadataValue = Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined;
 
+    const preferredStatus = this.selectPreferredWorkflowStatus(existing.status, incoming.status);
+    const existingResolvedAt = existing.resolvedAt ?? null;
+    const incomingResolvedAt = incoming.resolvedAt ?? null;
+
+    const resolvedAtForStatus = preferredStatus === "resolved"
+      ? existingResolvedAt ?? incomingResolvedAt ?? null
+      : (existing.status === preferredStatus && existingResolvedAt !== null
+        ? existingResolvedAt
+        : incoming.status === preferredStatus && incomingResolvedAt !== null
+          ? incomingResolvedAt
+          : null);
+
+    const resolutionNotesForStatus =
+      preferredStatus === existing.status && existing.resolutionNotes !== undefined
+        ? existing.resolutionNotes
+        : preferredStatus === incoming.status && incoming.resolutionNotes !== undefined
+          ? incoming.resolutionNotes
+          : existing.resolutionNotes ?? incoming.resolutionNotes;
+
     const merged: AlertWithMatch = {
       ...incoming,
       metadata: metadataValue,
-      status: existing.status ?? incoming.status ?? "new",
-      resolvedAt:
-        existing.resolvedAt !== undefined
-          ? existing.resolvedAt
-          : incoming.resolvedAt ?? null,
-      resolutionNotes: existing.resolutionNotes ?? incoming.resolutionNotes,
+      status: preferredStatus,
+      resolvedAt: resolvedAtForStatus,
+      resolutionNotes: resolutionNotesForStatus,
     };
 
     if (!merged.mcNumber && existing.mcNumber) {
@@ -626,6 +649,23 @@ export class DataManager {
     }
 
     return "new";
+  }
+
+  private selectPreferredWorkflowStatus(
+    existingStatus: AlertWorkflowStatus | null | undefined,
+    incomingStatus: AlertWorkflowStatus | null | undefined,
+  ): AlertWorkflowStatus {
+    const normalizedExisting = this.normalizeWorkflowStatus(existingStatus);
+    const normalizedIncoming = this.normalizeWorkflowStatus(incomingStatus);
+
+    if (normalizedExisting === normalizedIncoming) {
+      return normalizedExisting;
+    }
+
+    const existingPriority = DataManager.ALERT_WORKFLOW_PRIORITY.indexOf(normalizedExisting);
+    const incomingPriority = DataManager.ALERT_WORKFLOW_PRIORITY.indexOf(normalizedIncoming);
+
+    return incomingPriority > existingPriority ? normalizedIncoming : normalizedExisting;
   }
 
   private normalizeMatchStatus(value: unknown): AlertWithMatch["matchStatus"] {


### PR DESCRIPTION
App.tsx: resolve handler now feeds DataManager the canonical alert storage key to keep the UI and persistence in sync, plus optimistic override cleanup and success toast protection.
DataManager.ts & DataManager.test.ts: earlier regression coverage and merge tweaks already on this branch remain intact.
App.alertResolution.test.tsx: new regression test that mounts the app with mocked providers, resolves a matched alert, and confirms the canonical key flows into updateAlertStatus.