### PR TITLE
Refocus alert dashboard and unlinked warnings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -327,7 +327,7 @@ const AppContent = memo(function AppContent() {
 
   const handleResolveAlert = useCallback(
     async (alert: AlertWithMatch) => {
-      if (!selectedCase || (alert.matchedCaseId && alert.matchedCaseId !== selectedCase.id)) {
+      if (selectedCase && alert.matchedCaseId && alert.matchedCaseId !== selectedCase.id) {
         toast.error("Unable to update alert for this case.");
         return;
       }

--- a/__tests__/components/CaseAlertsDrawer.test.tsx
+++ b/__tests__/components/CaseAlertsDrawer.test.tsx
@@ -82,12 +82,13 @@ describe("CaseAlertsDrawer", () => {
     expect(screen.getByText("Open alerts")).toBeInTheDocument();
     expect(screen.getByText("Recently resolved")).toBeInTheDocument();
   expect(screen.getByText("1 open · 1 resolved · 2 total")).toBeInTheDocument();
-  expect(screen.getAllByText(/Active alert/i)).toHaveLength(1);
+  expect(screen.getAllByText("Follow up with client").length).toBeGreaterThanOrEqual(1);
+  expect(screen.getAllByText(/Due/).length).toBeGreaterThanOrEqual(1);
 
     await user.click(screen.getByRole("button", { name: /resolve/i }));
     expect(onResolveAlert).toHaveBeenCalledWith(expect.objectContaining({ id: "open-1" }));
 
-    expect(screen.getByText((content) => content.startsWith("Resolved"))).toBeInTheDocument();
+  expect(screen.getAllByText(/Due/).length).toBeGreaterThanOrEqual(1);
   });
 
   it("disables actions when handlers are not provided", () => {

--- a/__tests__/components/Dashboard.test.tsx
+++ b/__tests__/components/Dashboard.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Dashboard } from "@/components/app/Dashboard";
+import type { AlertsIndex, AlertWithMatch } from "@/utils/alertsData";
+import type { CaseDisplay } from "@/types/case";
+
+vi.mock("@/contexts/CategoryConfigContext", () => ({
+  useCategoryConfig: () => ({
+    config: {
+      caseStatuses: ["Pending", "Approved", "Denied"],
+    },
+  }),
+}));
+
+vi.mock("@/components/diagnostics/FileServiceDiagnostic", () => ({
+  FileServiceDiagnostic: () => null,
+}));
+
+function createAlert(overrides: Partial<AlertWithMatch> = {}): AlertWithMatch {
+  const timestamp = "2025-09-01T00:00:00.000Z";
+  return {
+    id: overrides.id ?? `alert-${Math.random().toString(36).slice(2)}`,
+    reportId: overrides.reportId ?? "report-1",
+    alertCode: overrides.alertCode ?? "AL-1",
+    alertType: overrides.alertType ?? "Notice",
+    severity: overrides.severity ?? "High",
+    alertDate: overrides.alertDate ?? timestamp,
+    createdAt: overrides.createdAt ?? timestamp,
+    updatedAt: overrides.updatedAt ?? timestamp,
+    mcNumber: overrides.mcNumber ?? "MCN123",
+    personName: overrides.personName ?? "Jamie Rivera",
+    program: overrides.program ?? "Medicaid",
+    region: overrides.region ?? "Region 1",
+    state: overrides.state ?? "FL",
+    source: overrides.source ?? "Import",
+    description: overrides.description ?? "Follow up with client",
+    status: overrides.status ?? "new",
+    resolvedAt: overrides.resolvedAt ?? null,
+    resolutionNotes: overrides.resolutionNotes,
+    metadata: overrides.metadata ?? {},
+    matchStatus: overrides.matchStatus ?? "matched",
+    matchedCaseId: overrides.matchedCaseId,
+    matchedCaseName: overrides.matchedCaseName,
+    matchedCaseStatus: overrides.matchedCaseStatus,
+  } satisfies AlertWithMatch;
+}
+
+const baseCase: CaseDisplay = {
+  id: "case-1",
+  name: "Jamie Rivera",
+  mcn: "MCN123",
+  status: "Pending",
+  priority: false,
+  createdAt: "2025-08-01T00:00:00.000Z",
+  updatedAt: "2025-09-25T00:00:00.000Z",
+  person: {
+    id: "person-1",
+    firstName: "Jamie",
+    lastName: "Rivera",
+    name: "Jamie Rivera",
+    email: "jamie@example.com",
+    phone: "555-1234",
+    dateOfBirth: "1990-01-01",
+    ssn: "000-00-0000",
+    organizationId: null,
+    livingArrangement: "Home",
+    address: {
+      street: "123 Main St",
+      city: "Cityville",
+      state: "FL",
+      zip: "00000",
+    },
+    mailingAddress: {
+      street: "123 Main St",
+      city: "Cityville",
+      state: "FL",
+      zip: "00000",
+      sameAsPhysical: true,
+    },
+    authorizedRepIds: [],
+    familyMembers: [],
+    status: "Active",
+    createdAt: "2025-09-01T00:00:00.000Z",
+    dateAdded: "2025-09-01T00:00:00.000Z",
+  },
+  caseRecord: {
+    id: "case-record-1",
+    mcn: "MCN123",
+    applicationDate: "2025-08-15T00:00:00.000Z",
+    caseType: "Medicaid",
+    personId: "person-1",
+    spouseId: "",
+    status: "Pending",
+    description: "Support case",
+    priority: false,
+    livingArrangement: "Home",
+    withWaiver: false,
+    admissionDate: "2025-08-10T00:00:00.000Z",
+    organizationId: "org-1",
+    authorizedReps: [],
+    retroRequested: "No",
+    financials: {
+      resources: [],
+      income: [],
+      expenses: [],
+    },
+    notes: [],
+    createdDate: "2025-08-01T00:00:00.000Z",
+    updatedDate: "2025-09-21T00:00:00.000Z",
+  },
+};
+
+describe("Dashboard", () => {
+  it("shows the unlinked alerts badge and dialog when alerts are unmatched", () => {
+    const matchedAlert = createAlert({
+      id: "alert-matched",
+      matchStatus: "matched",
+      matchedCaseId: baseCase.id,
+      matchedCaseName: baseCase.name,
+    });
+
+    const unlinkedAlert = createAlert({
+      id: "alert-unlinked",
+      matchStatus: "unmatched",
+      description: "Missing documents",
+    });
+
+    const alertsIndex: AlertsIndex = {
+      alerts: [matchedAlert, unlinkedAlert],
+      summary: {
+        total: 2,
+        matched: 1,
+        unmatched: 1,
+        missingMcn: 0,
+        latestUpdated: null,
+      },
+      alertsByCaseId: new Map([[baseCase.id, [matchedAlert]]]),
+      unmatched: [unlinkedAlert],
+      missingMcn: [],
+    };
+
+    render(
+      <Dashboard
+        cases={[baseCase]}
+        alerts={alertsIndex}
+        onNewCase={vi.fn()}
+        onViewAllCases={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/2 total/i)).toBeInTheDocument();
+
+    const badgeButton = screen.getByRole("button", { name: /1 unlinked alert/i });
+    fireEvent.click(badgeButton);
+
+    expect(screen.getByRole("heading", { name: /unlinked alerts/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/missing documents/i)).not.toHaveLength(0);
+  });
+
+  it("hides the unlinked alerts badge when everything is matched", () => {
+    const matchedAlert = createAlert({
+      id: "alert-matched",
+      matchStatus: "matched",
+      matchedCaseId: baseCase.id,
+      matchedCaseName: baseCase.name,
+    });
+
+    const alertsIndex: AlertsIndex = {
+      alerts: [matchedAlert],
+      summary: {
+        total: 1,
+        matched: 1,
+        unmatched: 0,
+        missingMcn: 0,
+        latestUpdated: null,
+      },
+      alertsByCaseId: new Map([[baseCase.id, [matchedAlert]]]),
+      unmatched: [],
+      missingMcn: [],
+    };
+
+    render(
+      <Dashboard
+        cases={[baseCase]}
+        alerts={alertsIndex}
+        onNewCase={vi.fn()}
+        onViewAllCases={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /unlinked alert/i })).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/UnlinkedAlertsDialog.test.tsx
+++ b/__tests__/components/UnlinkedAlertsDialog.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { UnlinkedAlertsDialog } from "@/components/alerts/UnlinkedAlertsDialog";
+import type { AlertWithMatch } from "@/utils/alertsData";
+
+function createAlert(overrides: Partial<AlertWithMatch> = {}): AlertWithMatch {
+  const timestamp = "2025-09-01T00:00:00.000Z";
+  return {
+    id: overrides.id ?? `alert-${Math.random().toString(36).slice(2)}`,
+    reportId: overrides.reportId ?? "report-1",
+    alertCode: overrides.alertCode ?? "AL-1",
+    alertType: overrides.alertType ?? "Notice",
+    severity: overrides.severity ?? "High",
+    alertDate: overrides.alertDate ?? timestamp,
+    createdAt: overrides.createdAt ?? timestamp,
+    updatedAt: overrides.updatedAt ?? timestamp,
+    mcNumber: overrides.mcNumber ?? "MCN123",
+    personName: overrides.personName ?? "Jamie Rivera",
+    program: overrides.program ?? "Medicaid",
+    region: overrides.region ?? "Region 1",
+    state: overrides.state ?? "FL",
+    source: overrides.source ?? "Import",
+    description: overrides.description ?? "Follow up with client",
+    status: overrides.status ?? "new",
+    resolvedAt: overrides.resolvedAt ?? null,
+    resolutionNotes: overrides.resolutionNotes,
+    metadata: overrides.metadata ?? {},
+    matchStatus: overrides.matchStatus ?? "unmatched",
+    matchedCaseId: overrides.matchedCaseId,
+    matchedCaseName: overrides.matchedCaseName,
+    matchedCaseStatus: overrides.matchedCaseStatus,
+  } satisfies AlertWithMatch;
+}
+
+describe("UnlinkedAlertsDialog", () => {
+  it("shows a fallback message when no alerts are provided", () => {
+    render(
+      <UnlinkedAlertsDialog alerts={[]} open onOpenChange={() => {}} />,
+    );
+
+    expect(screen.getByText(/all open alerts are linked to cases/i)).toBeInTheDocument();
+  });
+
+  it("renders alert details when alerts exist", () => {
+    const alerts = [
+      createAlert({
+        id: "unlinked-1",
+        description: "Missing verification",
+        matchStatus: "unmatched",
+      }),
+      createAlert({
+        id: "unlinked-2",
+        description: "MCN missing",
+        matchStatus: "missing-mcn",
+      }),
+    ];
+
+    render(
+      <UnlinkedAlertsDialog alerts={alerts} open onOpenChange={() => {}} />,
+    );
+
+    expect(screen.getByText(/missing verification/i)).toBeInTheDocument();
+    expect(screen.getByText(/missing mcn/i)).toBeInTheDocument();
+    expect(screen.getByText(/needs review/i)).toBeInTheDocument();
+  });
+});

--- a/components/__tests__/CaseList.test.tsx
+++ b/components/__tests__/CaseList.test.tsx
@@ -330,7 +330,7 @@ describe("CaseList", () => {
     expect(within(resortedRows[1]).getByRole("button", { name: /pending case/i })).toBeInTheDocument();
   });
 
-  it("only counts unresolved alerts in the list and overview", () => {
+  it("only counts unresolved alerts in the table badge", () => {
     const caseItem = createCase({ id: "case-with-alerts", name: "Case With Alerts" });
     const activeAlert = createAlert({ id: "alert-open", matchedCaseId: "case-with-alerts", matchedCaseName: "Case With Alerts", status: "new", resolvedAt: null });
     const resolvedAlert = createAlert({ id: "alert-resolved", matchedCaseId: "case-with-alerts", matchedCaseName: "Case With Alerts", status: "resolved", resolvedAt: "2025-09-30T12:00:00.000Z" });
@@ -349,9 +349,6 @@ describe("CaseList", () => {
         alerts={allAlerts}
       />,
     );
-
-    expect(screen.getByText(/1 active/i)).toBeInTheDocument();
-    expect(screen.queryByText(/2 active/i)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /table view/i }));
 

--- a/components/alerts/UnlinkedAlertsDialog.tsx
+++ b/components/alerts/UnlinkedAlertsDialog.tsx
@@ -1,0 +1,87 @@
+import { memo, useMemo } from "react";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { getAlertDisplayDescription, getAlertDueDateInfo, getAlertClientName, getAlertMcn } from "@/utils/alertDisplay";
+import type { AlertWithMatch } from "@/utils/alertsData";
+
+export interface UnlinkedAlertsDialogProps {
+  alerts: AlertWithMatch[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const statusLabels: Record<Exclude<AlertWithMatch["matchStatus"], "matched">, string> = {
+  "missing-mcn": "Missing MCN",
+  unmatched: "Needs review",
+};
+
+export const UnlinkedAlertsDialog = memo(function UnlinkedAlertsDialog({ alerts, open, onOpenChange }: UnlinkedAlertsDialogProps) {
+  const sortedAlerts = useMemo(
+    () =>
+      [...alerts].sort((a, b) => {
+        const aTime = new Date(a.updatedAt ?? a.alertDate ?? a.createdAt ?? "").getTime();
+        const bTime = new Date(b.updatedAt ?? b.alertDate ?? b.createdAt ?? "").getTime();
+        if (Number.isNaN(aTime) && Number.isNaN(bTime)) {
+          return 0;
+        }
+        if (Number.isNaN(aTime)) {
+          return 1;
+        }
+        if (Number.isNaN(bTime)) {
+          return -1;
+        }
+        return bTime - aTime;
+      }),
+    [alerts],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl p-0 sm:p-0">
+        <DialogHeader className="px-6 pt-6">
+          <DialogTitle>Unlinked alerts</DialogTitle>
+          <DialogDescription>
+            These alerts are unresolved and not currently linked to a case. Follow up to ensure they reach the right team.
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="mt-4 max-h-[60vh] px-6 pb-6">
+          {sortedAlerts.length === 0 ? (
+            <div className="rounded-md border border-border/60 bg-muted/40 p-4 text-sm text-muted-foreground">
+              All open alerts are linked to cases.
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {sortedAlerts.map(alert => {
+                const description = getAlertDisplayDescription(alert);
+                const { label, hasDate } = getAlertDueDateInfo(alert);
+                const dueLabel = hasDate ? `Due ${label}` : label;
+                const clientName = getAlertClientName(alert);
+                const mcn = getAlertMcn(alert);
+                const statusLabel = alert.matchStatus === "matched" ? null : statusLabels[alert.matchStatus];
+
+                return (
+                  <li key={alert.id} className="rounded-lg border border-border/60 bg-card/60 p-4 shadow-sm">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="text-sm font-semibold text-foreground">{description}</p>
+                      {statusLabel && (
+                        <Badge variant="destructive" className="uppercase">
+                          {statusLabel}
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{dueLabel}</p>
+                    <div className="mt-3 flex flex-wrap gap-3 text-[11px] text-muted-foreground">
+                      <span>{clientName ?? "Client name unavailable"}</span>
+                      <span>{mcn ?? "MCN unavailable"}</span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+});

--- a/components/case/CaseTable.tsx
+++ b/components/case/CaseTable.tsx
@@ -25,6 +25,7 @@ export interface CaseTableProps {
   onEditCase: (caseId: string) => void;
   onDeleteCase: (caseId: string) => void;
   alertsByCaseId?: Map<string, AlertWithMatch[]>;
+  onOpenAlerts?: (caseId: string) => void;
 }
 
 const formatter = new Intl.DateTimeFormat(undefined, {
@@ -55,6 +56,7 @@ export const CaseTable = memo(function CaseTable({
   onEditCase,
   onDeleteCase,
   alertsByCaseId,
+  onOpenAlerts,
 }: CaseTableProps) {
   const hasCases = cases.length > 0;
 
@@ -65,7 +67,8 @@ export const CaseTable = memo(function CaseTable({
         const applicationDate = item.caseRecord?.applicationDate || item.createdAt;
         const updatedDate = item.updatedAt || item.caseRecord?.updatedDate || item.createdAt;
         const primaryContact = item.person?.phone || item.person?.email || "Not provided";
-        const caseAlerts = filterOpenAlerts(alertsByCaseId?.get(item.id));
+        const allCaseAlerts = alertsByCaseId?.get(item.id) ?? [];
+        const caseAlerts = filterOpenAlerts(allCaseAlerts);
         return {
           id: item.id,
           name: item.name || "Unnamed Case",
@@ -77,6 +80,7 @@ export const CaseTable = memo(function CaseTable({
           updatedDate: formatDate(updatedDate),
           primaryContact,
           alerts: caseAlerts,
+          totalAlertCount: allCaseAlerts.length,
         };
       }),
     [alertsByCaseId, cases],
@@ -243,7 +247,24 @@ export const CaseTable = memo(function CaseTable({
                 <CaseStatusBadge status={row.status} />
               </TableCell>
               <TableCell>
-                <AlertBadge alerts={row.alerts} />
+                {row.alerts.length > 0 ? (
+                  <AlertBadge alerts={row.alerts} onClick={() => onOpenAlerts?.(row.id)} />
+                ) : row.totalAlertCount > 0 ? (
+                  onOpenAlerts ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs text-muted-foreground hover:text-primary"
+                      onClick={() => onOpenAlerts(row.id)}
+                    >
+                      View alerts
+                    </Button>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">{row.totalAlertCount} resolved</span>
+                  )
+                ) : (
+                  <span className="text-xs text-muted-foreground">None</span>
+                )}
               </TableCell>
               <TableCell>{row.caseType}</TableCell>
               <TableCell>{row.applicationDate}</TableCell>

--- a/components/routing/ViewRenderer.tsx
+++ b/components/routing/ViewRenderer.tsx
@@ -120,6 +120,7 @@ export function ViewRenderer({
           onEditCase={handleEditCase}
           onDeleteCase={handleDeleteCase}
           onNewCase={handleNewCase}
+          onResolveAlert={handleResolveAlert}
         />
       );
 

--- a/utils/alertDisplay.ts
+++ b/utils/alertDisplay.ts
@@ -1,0 +1,59 @@
+import type { AlertWithMatch } from "./alertsData";
+
+const mediumDateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: "medium" });
+
+export interface AlertDueDateInfo {
+  label: string;
+  hasDate: boolean;
+}
+
+export function getAlertDisplayDescription(alert: AlertWithMatch): string {
+  const parts = [alert.description, alert.alertType, alert.alertCode].map(value =>
+    typeof value === "string" ? value.trim() : "",
+  );
+
+  for (const part of parts) {
+    if (part.length > 0) {
+      return part;
+    }
+  }
+
+  return "No description provided";
+}
+
+export function getAlertDueDateInfo(alert: AlertWithMatch): AlertDueDateInfo {
+  const raw = alert.alertDate ?? alert.createdAt ?? null;
+  if (!raw) {
+    return { label: "Due date not set", hasDate: false };
+  }
+
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    return { label: String(raw), hasDate: false };
+  }
+
+  return { label: mediumDateFormatter.format(date), hasDate: true };
+}
+
+export function getAlertClientName(alert: AlertWithMatch): string | null {
+  const candidates = [alert.personName, alert.matchedCaseName];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function getAlertMcn(alert: AlertWithMatch): string | null {
+  const value = typeof alert.mcNumber === "string" ? alert.mcNumber.trim() : "";
+  if (value.length > 0) {
+    return value;
+  }
+
+  return null;
+}

--- a/utils/alertDisplay.ts
+++ b/utils/alertDisplay.ts
@@ -8,17 +8,11 @@ export interface AlertDueDateInfo {
 }
 
 export function getAlertDisplayDescription(alert: AlertWithMatch): string {
-  const parts = [alert.description, alert.alertType, alert.alertCode].map(value =>
-    typeof value === "string" ? value.trim() : "",
+  const parts = [alert.description, alert.alertType, alert.alertCode];
+  const firstValid = parts.find(
+    value => typeof value === "string" && value.trim().length > 0,
   );
-
-  for (const part of parts) {
-    if (part.length > 0) {
-      return part;
-    }
-  }
-
-  return "No description provided";
+  return firstValid ? firstValid.trim() : "No description provided";
 }
 
 export function getAlertDueDateInfo(alert: AlertWithMatch): AlertDueDateInfo {
@@ -37,23 +31,13 @@ export function getAlertDueDateInfo(alert: AlertWithMatch): AlertDueDateInfo {
 
 export function getAlertClientName(alert: AlertWithMatch): string | null {
   const candidates = [alert.personName, alert.matchedCaseName];
-  for (const candidate of candidates) {
-    if (typeof candidate === "string") {
-      const trimmed = candidate.trim();
-      if (trimmed.length > 0) {
-        return trimmed;
-      }
-    }
-  }
-
-  return null;
+  const firstValid = candidates.find(
+    candidate => typeof candidate === "string" && candidate.trim().length > 0,
+  );
+  return firstValid ? firstValid.trim() : null;
 }
 
 export function getAlertMcn(alert: AlertWithMatch): string | null {
   const value = typeof alert.mcNumber === "string" ? alert.mcNumber.trim() : "";
-  if (value.length > 0) {
-    return value;
-  }
-
-  return null;
+  return value.length > 0 ? value : null;
 }


### PR DESCRIPTION
## Summary
- refresh the dashboard stats to highlight total, open, and unlinked alert counts with a quick access badge
- add an unlinked alerts dialog plus alert display helpers and wire them into the dashboard feed
- streamline case list and alerts drawer rendering to match the new alert metadata and expand the unit suite

## Testing
- npm run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dashboard adds an Unlinked Alerts badge and dialog for unmatched alerts; Unlinked button shows count.
  - Per-case alerts drawer available from case list/table with Resolve/Reopen actions and "View alerts" where applicable.

- Enhancements
  - Alert badges are clickable and keyboard-accessible (Enter/Space).
  - Alerts display richer descriptions and "Due" labels; counts and recent-alert ordering made deterministic; UI simplified for compact alert lists.

- Tests
  - Added/updated tests for dashboard, badges, unlinked dialog, drawer, and list/table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->