### PR TITLE
feat: centralize MCN copy interaction

### DIFF
--- a/__tests__/components/CaseDetails.test.tsx
+++ b/__tests__/components/CaseDetails.test.tsx
@@ -8,7 +8,7 @@ import type { AlertWithMatch } from "@/utils/alertsData";
 const caseSectionPropsSpy = vi.fn();
 const notesSectionPropsSpy = vi.fn();
 const statusBadgePropsSpy = vi.fn();
-const clickToCopyMock = vi.fn();
+const clickToCopyMock = vi.fn().mockResolvedValue(true);
 
 vi.mock("@/components/ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
@@ -172,12 +172,10 @@ describe("CaseDetails", () => {
     await user.click(screen.getByRole("button", { name: /delete case/i }));
     expect(onDelete).toHaveBeenCalledTimes(1);
 
-    const copyButton = screen.getByRole("button", { name: /copy mcn to clipboard/i });
+    const copyButton = screen.getByRole("button", { name: new RegExp(`copy mcn ${caseData.mcn}`, "i") });
     await user.click(copyButton);
-    expect(clickToCopyMock).toHaveBeenCalledWith(
-      caseData.mcn,
-      expect.objectContaining({ successMessage: expect.stringContaining(caseData.mcn) })
-    );
+    expect(copyButton).toHaveAttribute("aria-label", `Copy MCN ${caseData.mcn}`);
+    expect(clickToCopyMock).toHaveBeenCalledWith(caseData.mcn);
 
     await user.click(screen.getByTestId("status-badge"));
     expect(onUpdateStatus).toHaveBeenCalledWith(caseData.id, "Approved");

--- a/__tests__/components/CaseListCopy.test.tsx
+++ b/__tests__/components/CaseListCopy.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CaseList } from "@/components/case/CaseList";
+import { createMockCaseDisplay } from "@/src/test/testUtils";
+
+const clickToCopyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/utils/clipboard", () => ({
+  clickToCopy: (...args: unknown[]) => clickToCopyMock(...args),
+}));
+
+vi.mock("@/utils/setupData", () => ({
+  setupSampleData: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("CaseList MCN copy accessibility", () => {
+  beforeEach(() => {
+    clickToCopyMock.mockReset();
+    clickToCopyMock.mockResolvedValue(true);
+    localStorage.clear();
+  });
+
+  it("provides an accessible MCN copy control in the table view", async () => {
+    const user = userEvent.setup();
+    const caseData = createMockCaseDisplay();
+
+    window.localStorage.setItem(
+      "cmsnext.fileStorageFlags",
+      JSON.stringify({ caseListView: "table" }),
+    );
+
+    render(
+      <CaseList
+        cases={[caseData]}
+        onViewCase={vi.fn()}
+        onEditCase={vi.fn()}
+        onDeleteCase={vi.fn()}
+        onNewCase={vi.fn()}
+      />,
+    );
+
+    const copyButton = await screen.findByRole("button", {
+      name: new RegExp(`copy mcn ${caseData.mcn}`, "i"),
+    });
+
+    await user.click(copyButton);
+
+    expect(copyButton).toHaveAttribute("aria-label", `Copy MCN ${caseData.mcn}`);
+    expect(clickToCopyMock).toHaveBeenCalledWith(caseData.mcn);
+  });
+});

--- a/components/__tests__/CaseDetails.test.tsx
+++ b/components/__tests__/CaseDetails.test.tsx
@@ -6,7 +6,7 @@ import type { CaseDisplay } from '@/types/case';
 
 const clickToCopyMock = vi.fn().mockResolvedValue(true);
 
-vi.mock('../../utils/clipboard', () => ({
+vi.mock('@/utils/clipboard', () => ({
   clickToCopy: clickToCopyMock,
 }));
 
@@ -338,12 +338,11 @@ describe('CaseDetails Memory Management', () => {
 
     render(<CaseDetails {...mockProps} />);
 
-    const copyButton = screen.getByRole('button', { name: /copy mcn to clipboard/i });
+    const copyButton = screen.getByRole('button', { name: /copy mcn 12345/i });
     await user.click(copyButton);
 
-    expect(clickToCopyMock).toHaveBeenCalledWith('12345', {
-      successMessage: 'MCN 12345 copied',
-    });
+    expect(clickToCopyMock).toHaveBeenCalledWith('12345');
+    expect(copyButton).toHaveAttribute('aria-label', 'Copy MCN 12345');
   });
 
   it('calls navigation handlers when action buttons are clicked', async () => {

--- a/components/__tests__/CaseDetails.test.tsx
+++ b/components/__tests__/CaseDetails.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CaseDetails } from '@/components/case/CaseDetails';
 import type { CaseDisplay } from '@/types/case';
 
-const clickToCopyMock = vi.fn().mockResolvedValue(true);
+const clickToCopyMock = vi.fn((text: string) => Promise.resolve(true));
 
 vi.mock('@/utils/clipboard', () => ({
   clickToCopy: clickToCopyMock,

--- a/components/alerts/UnlinkedAlertsDialog.tsx
+++ b/components/alerts/UnlinkedAlertsDialog.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
 import { getAlertDisplayDescription, getAlertDueDateInfo, getAlertClientName, getAlertMcn } from "@/utils/alertDisplay";
+import { McnCopyControl } from "@/components/common/McnCopyControl";
 import type { AlertWithMatch } from "@/utils/alertsData";
 
 export interface UnlinkedAlertsDialogProps {
@@ -73,7 +74,16 @@ export const UnlinkedAlertsDialog = memo(function UnlinkedAlertsDialog({ alerts,
                     <p className="mt-1 text-xs text-muted-foreground">{dueLabel}</p>
                     <div className="mt-3 flex flex-wrap gap-3 text-[11px] text-muted-foreground">
                       <span>{clientName ?? "Client name unavailable"}</span>
-                      <span>{mcn ?? "MCN unavailable"}</span>
+                      <McnCopyControl
+                        mcn={mcn}
+                        showLabel={false}
+                        className="inline-flex items-center gap-1 text-[11px] text-muted-foreground"
+                        buttonClassName="text-[11px] text-muted-foreground"
+                        textClassName="text-[11px]"
+                        missingLabel="MCN unavailable"
+                        missingClassName="text-[11px] text-muted-foreground"
+                        variant="plain"
+                      />
                     </div>
                   </li>
                 );

--- a/components/app/Dashboard.tsx
+++ b/components/app/Dashboard.tsx
@@ -10,6 +10,7 @@ import { BellRing } from "lucide-react";
 import { filterOpenAlerts, type AlertsIndex } from "../../utils/alertsData";
 import { getAlertClientName, getAlertDisplayDescription, getAlertDueDateInfo, getAlertMcn } from "@/utils/alertDisplay";
 import { UnlinkedAlertsDialog } from "@/components/alerts/UnlinkedAlertsDialog";
+import { McnCopyControl } from "@/components/common/McnCopyControl";
 
 interface DashboardProps {
   cases: CaseDisplay[];
@@ -178,8 +179,18 @@ export function Dashboard({ cases, alerts, onViewAllCases, onNewCase }: Dashboar
                       <div className="font-medium text-foreground">
                         {case_.person.firstName} {case_.person.lastName}
                       </div>
-                      <div className="text-sm text-muted-foreground">
-                        MCN: {case_.caseRecord?.mcn || 'N/A'} • Status: {case_.caseRecord?.status || 'Unknown'}
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+                        <McnCopyControl
+                          mcn={case_.caseRecord?.mcn ?? null}
+                          className="inline-flex items-center gap-1 text-muted-foreground"
+                          labelClassName="text-sm font-normal text-muted-foreground"
+                          buttonClassName="text-sm text-muted-foreground"
+                          textClassName="text-sm"
+                          missingLabel="N/A"
+                          missingClassName="text-sm text-muted-foreground"
+                          variant="plain"
+                        />
+                        <span>• Status: {case_.caseRecord?.status || 'Unknown'}</span>
                       </div>
                     </div>
                     <div className="text-xs text-muted-foreground">
@@ -261,7 +272,7 @@ export function Dashboard({ cases, alerts, onViewAllCases, onNewCase }: Dashboar
                     const { label, hasDate } = getAlertDueDateInfo(alert);
                     const dueLabel = hasDate ? `Due ${label}` : label;
                     const clientName = getAlertClientName(alert) ?? "Client name unavailable";
-                    const mcn = getAlertMcn(alert) ?? "MCN unavailable";
+                    const mcn = getAlertMcn(alert);
 
                     return (
                       <div
@@ -273,7 +284,16 @@ export function Dashboard({ cases, alerts, onViewAllCases, onNewCase }: Dashboar
                           <p className="text-xs text-muted-foreground">{dueLabel}</p>
                           <div className="flex flex-wrap gap-3 text-[11px] text-muted-foreground">
                             <span>{clientName}</span>
-                            <span>{mcn}</span>
+                            <McnCopyControl
+                              mcn={mcn}
+                              showLabel={false}
+                              className="inline-flex items-center gap-1 text-[11px] text-muted-foreground"
+                              buttonClassName="text-[11px] text-muted-foreground"
+                              textClassName="text-[11px]"
+                              missingLabel="MCN unavailable"
+                              missingClassName="text-[11px] text-muted-foreground"
+                              variant="plain"
+                            />
                           </div>
                         </div>
                       </div>

--- a/components/app/Dashboard.tsx
+++ b/components/app/Dashboard.tsx
@@ -186,7 +186,7 @@ export function Dashboard({ cases, alerts, onViewAllCases, onNewCase }: Dashboar
                           labelClassName="text-sm font-normal text-muted-foreground"
                           buttonClassName="text-sm text-muted-foreground"
                           textClassName="text-sm"
-                          missingLabel="N/A"
+                          missingLabel="MCN unavailable"
                           missingClassName="text-sm text-muted-foreground"
                           variant="plain"
                         />

--- a/components/case/CaseCard.tsx
+++ b/components/case/CaseCard.tsx
@@ -17,6 +17,7 @@ import { Eye, Edit, Trash2 } from "lucide-react";
 import { CaseStatusBadge } from "./CaseStatusBadge";
 import type { AlertWithMatch } from "../../utils/alertsData";
 import { AlertBadge } from "@/components/alerts/AlertBadge";
+import { McnCopyControl } from "@/components/common/McnCopyControl";
 
 interface CaseCardProps {
   case: CaseDisplay;
@@ -62,7 +63,13 @@ export function CaseCard({ case: caseData, onView, onEdit, onDelete, alerts = []
           <CaseStatusBadge status={caseData.status} />
         </div>
         <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-          <p>MCN: {caseData.mcn || 'No MCN'}</p>
+          <McnCopyControl
+            mcn={caseData.mcn}
+            className="text-muted-foreground"
+            labelClassName="text-sm"
+            textClassName="text-sm"
+            variant="muted"
+          />
           <AlertBadge alerts={alerts} />
         </div>
       </CardHeader>

--- a/components/case/CaseDetails.tsx
+++ b/components/case/CaseDetails.tsx
@@ -6,14 +6,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { CaseSection } from "./CaseSection";
 import { NotesSection } from "./NotesSection";
 import { CaseDisplay, CaseCategory, FinancialItem, NewNoteData } from "../../types/case";
-import { ArrowLeft, Edit2, Trash2, Landmark, Wallet, Receipt, Copy, BellRing } from "lucide-react";
+import { ArrowLeft, Edit2, Trash2, Landmark, Wallet, Receipt, BellRing } from "lucide-react";
 import { withDataErrorBoundary } from "../error/ErrorBoundaryHOC";
 import { CaseStatusBadge } from "./CaseStatusBadge";
-import { clickToCopy } from "../../utils/clipboard";
 import { Badge } from "../ui/badge";
 import { cn, interactiveHoverClasses } from "../ui/utils";
 import type { AlertWithMatch } from "../../utils/alertsData";
 import { CaseAlertsDrawer } from "./CaseAlertsDrawer";
+import { McnCopyControl } from "@/components/common/McnCopyControl";
 
 interface CaseDetailsProps {
   case: CaseDisplay;
@@ -120,31 +120,15 @@ export function CaseDetails({
                   onStatusChange={onUpdateStatus ? handleStatusChange : undefined}
                 />
               </div>
-              <div className="flex items-center gap-2 text-muted-foreground">
-                <span className="text-sm font-medium">MCN:</span>
-                {caseData.mcn ? (
-                  <button
-                    type="button"
-                    onClick={() =>
-                      void clickToCopy(caseData.mcn!, {
-                        successMessage: `MCN ${caseData.mcn} copied`,
-                      })
-                    }
-                    className={cn(
-                      interactiveHoverClasses,
-                      "inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 font-mono text-sm text-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                    )}
-                    aria-label="Copy MCN to clipboard"
-                  >
-                    <span>{caseData.mcn}</span>
-                    <Copy className="h-3.5 w-3.5" aria-hidden="true" />
-                  </button>
-                ) : (
-                  <span className="text-sm font-mono bg-muted px-2 py-0.5 rounded-md">
-                    No MCN
-                  </span>
-                )}
-              </div>
+              <McnCopyControl
+                mcn={caseData.mcn}
+                className="text-muted-foreground"
+                labelClassName="text-sm font-medium"
+                buttonClassName={cn(interactiveHoverClasses, "text-foreground")}
+                textClassName="text-sm"
+                variant="muted"
+                interactive
+              />
               <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                 {totalAlerts > 0 ? (
                   <div className="flex items-center gap-2">

--- a/components/case/CaseTable.tsx
+++ b/components/case/CaseTable.tsx
@@ -15,6 +15,7 @@ import { ArrowDown, ArrowUp, ArrowUpDown, Eye, MoreHorizontal, Pencil, Trash2 } 
 import type { CaseListSortDirection, CaseListSortKey } from "@/hooks/useCaseListPreferences";
 import { filterOpenAlerts, type AlertWithMatch } from "@/utils/alertsData";
 import { AlertBadge } from "@/components/alerts/AlertBadge";
+import { McnCopyControl } from "@/components/common/McnCopyControl";
 
 export interface CaseTableProps {
   cases: CaseDisplay[];
@@ -72,7 +73,7 @@ export const CaseTable = memo(function CaseTable({
         return {
           id: item.id,
           name: item.name || "Unnamed Case",
-          mcn: item.mcn || "No MCN",
+          mcn: item.mcn ?? null,
           status: item.status,
           priority: item.priority,
           caseType,
@@ -241,7 +242,16 @@ export const CaseTable = memo(function CaseTable({
                 </div>
               </TableCell>
               <TableCell>
-                <span className="text-sm text-muted-foreground">{row.mcn}</span>
+                <McnCopyControl
+                  mcn={row.mcn}
+                  showLabel={false}
+                  className="text-muted-foreground"
+                  buttonClassName="text-sm text-muted-foreground"
+                  textClassName="text-sm"
+                  missingLabel="No MCN"
+                  missingClassName="text-sm text-muted-foreground"
+                  variant="plain"
+                />
               </TableCell>
               <TableCell>
                 <CaseStatusBadge status={row.status} />

--- a/components/common/McnCopyControl.tsx
+++ b/components/common/McnCopyControl.tsx
@@ -40,7 +40,7 @@ export const McnCopyControl = memo(function McnCopyControl({
       return;
     }
 
-    void clickToCopy(mcn);
+    clickToCopy(mcn);
   }, [mcn]);
 
   const resolvedLabel = label?.trim() || DEFAULT_LABEL;

--- a/components/common/McnCopyControl.tsx
+++ b/components/common/McnCopyControl.tsx
@@ -1,0 +1,101 @@
+import { memo, useCallback } from "react";
+import { Copy } from "lucide-react";
+import { clickToCopy } from "@/utils/clipboard";
+import { cn, interactiveHoverClasses } from "@/components/ui/utils";
+
+export type McnCopyControlVariant = "muted" | "plain";
+
+export interface McnCopyControlProps {
+  mcn?: string | null;
+  label?: string;
+  showLabel?: boolean;
+  missingLabel?: string;
+  className?: string;
+  labelClassName?: string;
+  buttonClassName?: string;
+  textClassName?: string;
+  missingClassName?: string;
+  variant?: McnCopyControlVariant;
+  interactive?: boolean;
+}
+
+const DEFAULT_LABEL = "MCN";
+const DEFAULT_MISSING_LABEL = "No MCN";
+
+export const McnCopyControl = memo(function McnCopyControl({
+  mcn,
+  label = DEFAULT_LABEL,
+  showLabel = true,
+  missingLabel = DEFAULT_MISSING_LABEL,
+  className,
+  labelClassName,
+  buttonClassName,
+  textClassName,
+  missingClassName,
+  variant = "muted",
+  interactive = false,
+}: McnCopyControlProps) {
+  const handleCopy = useCallback(() => {
+    if (!mcn) {
+      return;
+    }
+
+    void clickToCopy(mcn);
+  }, [mcn]);
+
+  const resolvedLabel = label?.trim() || DEFAULT_LABEL;
+  const labelWithSuffix = resolvedLabel.endsWith(":") ? resolvedLabel : `${resolvedLabel}:`;
+
+  const wrapperClasses = cn("inline-flex items-center gap-2", className);
+
+  const baseButtonClasses = cn(
+    "group inline-flex items-center gap-1 rounded-md font-mono text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    variant === "plain"
+      ? "rounded-none border-b border-transparent px-0 py-0 text-muted-foreground hover:border-muted-foreground/70 hover:text-foreground focus-visible:border-muted-foreground"
+      : "bg-muted px-2 py-0.5 text-foreground hover:bg-muted/80",
+    interactive ? interactiveHoverClasses : undefined,
+    buttonClassName,
+  );
+
+  const textClasses = cn("truncate text-sm", textClassName);
+  const iconClasses = cn(
+    "h-3.5 w-3.5",
+    variant === "plain"
+      ? "text-muted-foreground transition-colors group-hover:text-foreground group-focus-visible:text-foreground"
+      : undefined,
+  );
+
+  if (!mcn) {
+    return (
+      <span className={wrapperClasses}>
+        {showLabel ? (
+          <span className={cn("text-sm font-medium text-muted-foreground", labelClassName)}>{labelWithSuffix}</span>
+        ) : null}
+        <span
+          className={cn(
+            "font-mono text-sm text-muted-foreground/80",
+            variant === "muted" ? "rounded-md bg-muted px-2 py-0.5" : undefined,
+            missingClassName,
+          )}
+        >
+          {missingLabel}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={wrapperClasses}>
+      {showLabel ? (
+        <span className={cn("text-sm font-medium text-muted-foreground", labelClassName)}>{labelWithSuffix}</span>
+      ) : null}
+      <button type="button" onClick={handleCopy} className={baseButtonClasses} aria-label={`Copy MCN ${mcn}`}>
+        <span className={textClasses}>{mcn}</span>
+        <Copy aria-hidden className={iconClasses} />
+      </button>
+    </span>
+  );
+});
+
+McnCopyControl.displayName = "McnCopyControl";
+


### PR DESCRIPTION
## Summary
- add a reusable McnCopyControl component that wraps click-to-copy with accessible styling
- replace ad-hoc MCN renderings across details, cards, tables, dashboard, and alerts with the shared control
- extend CaseDetails and CaseList test suites and add a CaseList copy interaction test to cover the new behavior

## Testing
- npm run test -- CaseDetails
- npm run test -- CaseList

------
https://chatgpt.com/codex/tasks/task_e_68e09ed333a0833289532ebf42d435f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable MCN copy control used across Case Details, Case Card, Case Table, Dashboard (Recent Cases, Alert Center) and Unlinked Alerts, with plain/muted variants, inline/compact display, and explicit missing‑MCN messaging.

* **Bug Fixes**
  * Improved accessibility and consistency: copy controls now expose dynamic, descriptive aria-labels and uniform clipboard behavior; tests added and updated to verify accessible naming and copy interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->