### PR TITLE
Refactor case status menu into reusable control

### DIFF
--- a/__tests__/components/CaseAlertsDrawer.test.tsx
+++ b/__tests__/components/CaseAlertsDrawer.test.tsx
@@ -94,7 +94,7 @@ describe("CaseAlertsDrawer", () => {
         caseName="John Doe"
         caseId="case-1"
         caseStatus="Pending"
-        onUpdateStatus={vi.fn()}
+        onUpdateCaseStatus={vi.fn()}
         onResolveAlert={onResolveAlert}
       />,
     );
@@ -129,7 +129,7 @@ describe("CaseAlertsDrawer", () => {
 
   it("invokes the status update handler from the header menu", async () => {
     const user = userEvent.setup();
-    const onUpdateStatus = vi.fn().mockResolvedValue(null);
+  const onUpdateCaseStatus = vi.fn().mockResolvedValue(null);
 
     const alert = buildAlert({ status: "new" });
 
@@ -141,7 +141,7 @@ describe("CaseAlertsDrawer", () => {
         caseName="Jane Doe"
         caseId="case-99"
         caseStatus="Pending"
-        onUpdateStatus={onUpdateStatus}
+        onUpdateCaseStatus={onUpdateCaseStatus}
       />,
     );
 
@@ -151,6 +151,6 @@ describe("CaseAlertsDrawer", () => {
     const approvedOption = await screen.findByRole("menuitemradio", { name: "Approved" });
     await user.click(approvedOption);
 
-    expect(onUpdateStatus).toHaveBeenCalledWith("case-99", "Approved");
+    expect(onUpdateCaseStatus).toHaveBeenCalledWith("case-99", "Approved");
   });
 });

--- a/__tests__/components/CaseDetails.test.tsx
+++ b/__tests__/components/CaseDetails.test.tsx
@@ -55,14 +55,14 @@ vi.mock("@/components/case/NotesSection", () => ({
 }));
 
 vi.mock("@/components/case/CaseAlertsDrawer", () => ({
-  CaseAlertsDrawer: ({ alerts, caseId, caseStatus, onUpdateStatus }: any) => {
+  CaseAlertsDrawer: ({ alerts, caseId, caseStatus, onUpdateCaseStatus }: any) => {
     return (
       <div
         data-testid="case-alerts-drawer"
         data-alert-count={alerts?.length ?? 0}
         data-case-id={caseId ?? ""}
         data-case-status={caseStatus ?? ""}
-        data-has-status-handler={Boolean(onUpdateStatus)}
+        data-has-status-handler={Boolean(onUpdateCaseStatus)}
       />
     );
   },

--- a/__tests__/components/CaseDetails.test.tsx
+++ b/__tests__/components/CaseDetails.test.tsx
@@ -7,8 +7,8 @@ import type { AlertWithMatch } from "@/utils/alertsData";
 
 const caseSectionPropsSpy = vi.fn();
 const notesSectionPropsSpy = vi.fn();
-const statusBadgePropsSpy = vi.fn();
-const clickToCopyMock = vi.fn().mockResolvedValue(true);
+const statusMenuPropsSpy = vi.fn();
+const clickToCopyMock = vi.fn();
 
 vi.mock("@/components/ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
@@ -55,19 +55,27 @@ vi.mock("@/components/case/NotesSection", () => ({
 }));
 
 vi.mock("@/components/case/CaseAlertsDrawer", () => ({
-  CaseAlertsDrawer: ({ alerts }: any) => (
-    <div data-testid="case-alerts-drawer" data-alert-count={alerts?.length ?? 0} />
-  ),
+  CaseAlertsDrawer: ({ alerts, caseId, caseStatus, onUpdateStatus }: any) => {
+    return (
+      <div
+        data-testid="case-alerts-drawer"
+        data-alert-count={alerts?.length ?? 0}
+        data-case-id={caseId ?? ""}
+        data-case-status={caseStatus ?? ""}
+        data-has-status-handler={Boolean(onUpdateStatus)}
+      />
+    );
+  },
 }));
 
-vi.mock("@/components/case/CaseStatusBadge", () => ({
-  CaseStatusBadge: (props: any) => {
-    statusBadgePropsSpy(props);
+vi.mock("@/components/case/CaseStatusMenu", () => ({
+  CaseStatusMenu: (props: any) => {
+    statusMenuPropsSpy(props);
     return (
       <button
         type="button"
         data-testid="status-badge"
-        onClick={() => props.onStatusChange?.("Approved")}
+        onClick={() => props.onUpdateStatus?.(props.caseId, "Approved")}
       >
         {props.status}
       </button>
@@ -159,7 +167,7 @@ describe("CaseDetails", () => {
     );
 
     expect(screen.getByRole("heading", { name: caseData.name })).toBeInTheDocument();
-  expect(screen.getByText(/1 open alert/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 open alert/i)).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /back/i }));
     expect(onBack).toHaveBeenCalledTimes(1);
@@ -167,8 +175,8 @@ describe("CaseDetails", () => {
     await user.click(screen.getByRole("button", { name: /edit/i }));
     expect(onEdit).toHaveBeenCalledTimes(1);
 
-  const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
-  await user.click(deleteButtons[0]);
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    await user.click(deleteButtons[0]);
     await user.click(screen.getByRole("button", { name: /delete case/i }));
     expect(onDelete).toHaveBeenCalledTimes(1);
 
@@ -192,8 +200,8 @@ describe("CaseDetails", () => {
     expect(notesSectionPropsSpy).toHaveBeenCalledWith(
       expect.objectContaining({ notes: caseData.caseRecord.notes })
     );
-    expect(statusBadgePropsSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ status: caseData.status })
+    expect(statusMenuPropsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ caseId: caseData.id, status: caseData.status })
     );
   });
 });

--- a/__tests__/components/CaseList.test.tsx
+++ b/__tests__/components/CaseList.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import CaseList from "@/components/case/CaseList";
-import type { CaseDisplay } from "@/types/case";
+import { CaseList } from "@/components/case/CaseList";
 import { mergeCategoryConfig } from "@/types/categoryConfig";
+import { createMockCaseDisplay } from "@/src/test/testUtils";
 
 const categoryConfigMock = mergeCategoryConfig({
   caseStatuses: ["Pending", "Approved", "Denied"],
@@ -40,32 +40,6 @@ vi.mock("@/components/case/CaseAlertsDrawer", () => ({
   CaseAlertsDrawer: () => <div data-testid="alerts-drawer" />,
 }));
 
-const buildCase = (overrides: Partial<CaseDisplay> = {}): CaseDisplay => ({
-  id: overrides.id ?? "case-1",
-  status: overrides.status ?? "Pending",
-  name: overrides.name ?? "Sample Case",
-  mcn: overrides.mcn ?? "ABC123",
-  createdAt: overrides.createdAt ?? new Date().toISOString(),
-  updatedAt: overrides.updatedAt ?? new Date().toISOString(),
-  caseRecord: overrides.caseRecord ?? {
-    id: "record-1",
-    caseType: "Housing",
-    applicationDate: new Date().toISOString(),
-    status: overrides.status ?? "Pending",
-    updatedDate: new Date().toISOString(),
-  },
-  person: overrides.person ?? {
-    id: "person-1",
-    firstName: "Jane",
-    lastName: "Doe",
-    email: "jane@example.com",
-    phone: "555-1234",
-  },
-  priority: overrides.priority ?? false,
-  alerts: overrides.alerts ?? [],
-  notes: overrides.notes ?? [],
-});
-
 describe("CaseList status interactions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,7 +49,7 @@ describe("CaseList status interactions", () => {
     const user = userEvent.setup();
     const onUpdateCaseStatus = vi.fn().mockResolvedValue({ status: "Approved" });
 
-    const cases = [buildCase()];
+  const cases = [createMockCaseDisplay({ id: "case-1" })];
 
     render(
       <CaseList

--- a/__tests__/components/CaseList.test.tsx
+++ b/__tests__/components/CaseList.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import CaseList from "@/components/case/CaseList";
+import type { CaseDisplay } from "@/types/case";
+import { mergeCategoryConfig } from "@/types/categoryConfig";
+
+const categoryConfigMock = mergeCategoryConfig({
+  caseStatuses: ["Pending", "Approved", "Denied"],
+});
+
+vi.mock("@/contexts/CategoryConfigContext", () => ({
+  useCategoryConfig: () => ({
+    config: categoryConfigMock,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    updateCategory: vi.fn(),
+    resetToDefaults: vi.fn(),
+    setConfigFromFile: vi.fn(),
+  }),
+}));
+
+const mockPreferences = {
+  viewMode: "table" as const,
+  setViewMode: vi.fn(),
+  sortKey: "updated" as const,
+  setSortKey: vi.fn(),
+  sortDirection: "desc" as const,
+  setSortDirection: vi.fn(),
+  segment: "all" as const,
+  setSegment: vi.fn(),
+};
+
+vi.mock("@/hooks/useCaseListPreferences", () => ({
+  useCaseListPreferences: () => mockPreferences,
+}));
+
+vi.mock("@/components/case/CaseAlertsDrawer", () => ({
+  CaseAlertsDrawer: () => <div data-testid="alerts-drawer" />,
+}));
+
+const buildCase = (overrides: Partial<CaseDisplay> = {}): CaseDisplay => ({
+  id: overrides.id ?? "case-1",
+  status: overrides.status ?? "Pending",
+  name: overrides.name ?? "Sample Case",
+  mcn: overrides.mcn ?? "ABC123",
+  createdAt: overrides.createdAt ?? new Date().toISOString(),
+  updatedAt: overrides.updatedAt ?? new Date().toISOString(),
+  caseRecord: overrides.caseRecord ?? {
+    id: "record-1",
+    caseType: "Housing",
+    applicationDate: new Date().toISOString(),
+    status: overrides.status ?? "Pending",
+    updatedDate: new Date().toISOString(),
+  },
+  person: overrides.person ?? {
+    id: "person-1",
+    firstName: "Jane",
+    lastName: "Doe",
+    email: "jane@example.com",
+    phone: "555-1234",
+  },
+  priority: overrides.priority ?? false,
+  alerts: overrides.alerts ?? [],
+  notes: overrides.notes ?? [],
+});
+
+describe("CaseList status interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("CaseList table updates status when a new option is selected", async () => {
+    const user = userEvent.setup();
+    const onUpdateCaseStatus = vi.fn().mockResolvedValue({ status: "Approved" });
+
+    const cases = [buildCase()];
+
+    render(
+      <CaseList
+        cases={cases}
+        onViewCase={vi.fn()}
+        onEditCase={vi.fn()}
+        onDeleteCase={vi.fn()}
+        onNewCase={vi.fn()}
+        alertsSummary={undefined}
+        alertsByCaseId={new Map()}
+        alerts={[]}
+        onUpdateCaseStatus={onUpdateCaseStatus}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /update case status/i });
+    expect(within(trigger).getByText("Pending")).toBeInTheDocument();
+
+    await user.click(trigger);
+
+    const approvedOption = await screen.findByRole("menuitemradio", { name: "Approved" });
+    await user.click(approvedOption);
+
+    expect(onUpdateCaseStatus).toHaveBeenCalledWith("case-1", "Approved");
+
+    await screen.findByText("Approved");
+    expect(within(trigger).getByText("Approved")).toBeInTheDocument();
+  });
+});

--- a/components/__tests__/CaseDetails.test.tsx
+++ b/components/__tests__/CaseDetails.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CaseDetails } from '@/components/case/CaseDetails';
 import type { CaseDisplay } from '@/types/case';
 
-const clickToCopyMock = vi.fn((text: string) => Promise.resolve(true));
+const clickToCopyMock = vi.fn(() => Promise.resolve(true));
 
 vi.mock('@/utils/clipboard', () => ({
   clickToCopy: clickToCopyMock,
@@ -39,15 +39,26 @@ vi.mock('../case/NotesSection', () => ({
   },
 }));
 
-vi.mock('../case/CaseStatusBadge', () => ({
-  CaseStatusBadge: ({ status }: any) => (
-    <div data-testid="case-status-badge">{status ?? 'Pending'}</div>
+vi.mock('../case/CaseStatusMenu', () => ({
+  CaseStatusMenu: (props: any) => (
+    <button
+      data-testid="case-status-badge"
+      onClick={() => props.onUpdateStatus?.(props.caseId, 'Approved')}
+    >
+      {props.status ?? 'Pending'}
+    </button>
   ),
 }));
 
 vi.mock('../case/CaseAlertsDrawer', () => ({
-  CaseAlertsDrawer: ({ alerts }: any) => (
-    <div data-testid="case-alerts-drawer" data-alert-count={alerts?.length ?? 0} />
+  CaseAlertsDrawer: ({ alerts, caseId, caseStatus, onUpdateCaseStatus }: any) => (
+    <div
+      data-testid="case-alerts-drawer"
+      data-alert-count={alerts?.length ?? 0}
+      data-case-id={caseId ?? ''}
+      data-case-status={caseStatus ?? ''}
+      data-has-status-handler={Boolean(onUpdateCaseStatus)}
+    />
   ),
 }));
 

--- a/components/app/VirtualCaseList.tsx
+++ b/components/app/VirtualCaseList.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useRef, memo } from 'react';
-import { CaseDisplay } from '@/types/case';
+import type { CaseDisplay, CaseStatusUpdateHandler } from '@/types/case';
 import { CaseCard } from '@/components/case/CaseCard';
 import type { AlertWithMatch } from '@/utils/alertsData';
 
@@ -10,10 +10,7 @@ interface VirtualCaseListProps {
   onEditCase: (caseId: string) => void;
   onDeleteCase: (caseId: string) => void;
   alertsByCaseId?: Map<string, AlertWithMatch[]>;
-  onUpdateCaseStatus?: (
-    caseId: string,
-    status: CaseDisplay["status"],
-  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
+  onUpdateCaseStatus?: CaseStatusUpdateHandler;
 }
 
 /**

--- a/components/app/VirtualCaseList.tsx
+++ b/components/app/VirtualCaseList.tsx
@@ -10,6 +10,10 @@ interface VirtualCaseListProps {
   onEditCase: (caseId: string) => void;
   onDeleteCase: (caseId: string) => void;
   alertsByCaseId?: Map<string, AlertWithMatch[]>;
+  onUpdateCaseStatus?: (
+    caseId: string,
+    status: CaseDisplay["status"],
+  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
 }
 
 /**
@@ -27,6 +31,7 @@ export const VirtualCaseList = memo(function VirtualCaseList({
   onEditCase,
   onDeleteCase,
   alertsByCaseId,
+  onUpdateCaseStatus,
 }: VirtualCaseListProps) {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -82,6 +87,7 @@ export const VirtualCaseList = memo(function VirtualCaseList({
                   onView={onViewCase}
                   onEdit={onEditCase}
                   onDelete={onDeleteCase}
+                  onUpdateStatus={onUpdateCaseStatus}
                   alerts={alertsByCaseId?.get(caseData.id) ?? []}
                 />
               </div>

--- a/components/case/CaseAlertsDrawer.tsx
+++ b/components/case/CaseAlertsDrawer.tsx
@@ -9,6 +9,8 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import type { AlertWithMatch } from "@/utils/alertsData";
+import { CaseStatusMenu } from "./CaseStatusMenu";
+import type { CaseDisplay } from "@/types/case";
 import { getAlertDisplayDescription, getAlertDueDateInfo } from "@/utils/alertDisplay";
 
 interface CaseAlertsDrawerProps {
@@ -17,6 +19,12 @@ interface CaseAlertsDrawerProps {
   onOpenChange: (open: boolean) => void;
   caseName: string;
   onResolveAlert?: (alert: AlertWithMatch) => void | Promise<void>;
+  caseId?: string;
+  caseStatus?: CaseDisplay["status"];
+  onUpdateStatus?: (
+    caseId: string,
+    status: CaseDisplay["status"],
+  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
 }
 
 export const CaseAlertsDrawer = memo(function CaseAlertsDrawer({
@@ -25,6 +33,9 @@ export const CaseAlertsDrawer = memo(function CaseAlertsDrawer({
   onOpenChange,
   caseName,
   onResolveAlert,
+  caseId,
+  caseStatus,
+  onUpdateStatus,
 }: CaseAlertsDrawerProps) {
   const handleResolve = useCallback(
     (alert: AlertWithMatch) => {
@@ -49,22 +60,34 @@ export const CaseAlertsDrawer = memo(function CaseAlertsDrawer({
   }, [alerts]);
 
   const totalAlerts = alerts.length;
+  const canUpdateStatus = Boolean(caseId && onUpdateStatus);
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="sm:max-w-md overflow-hidden">
         <SheetHeader className="border-b border-border/60 pb-4 shrink-0">
-          <SheetTitle className="flex flex-col gap-1 text-left">
-            Alerts for {caseName}
-            <span className="text-sm font-normal text-muted-foreground">
-              {openAlerts.length} open · {resolvedAlerts.length} resolved · {totalAlerts} total
-            </span>
-          </SheetTitle>
-          <SheetDescription className="text-left">
-            Review incoming alerts and resolve items—resolution notes are logged automatically.
-          </SheetDescription>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1 text-left sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+              <div>
+                <SheetTitle className="text-left">Alerts for {caseName}</SheetTitle>
+                <span className="text-sm font-normal text-muted-foreground">
+                  {openAlerts.length} open · {resolvedAlerts.length} resolved · {totalAlerts} total
+                </span>
+              </div>
+              {canUpdateStatus && caseId ? (
+                <CaseStatusMenu
+                  caseId={caseId}
+                  status={caseStatus}
+                  onUpdateStatus={onUpdateStatus}
+                />
+              ) : null}
+            </div>
+            <SheetDescription className="text-left">
+              Review incoming alerts and resolve items—resolution notes are logged automatically.
+            </SheetDescription>
+          </div>
         </SheetHeader>
-  <ScrollArea className="flex-1 min-h-0 overflow-y-auto px-4 pb-6">
+        <ScrollArea className="flex-1 min-h-0 overflow-y-auto px-4 pb-6">
           <section className="space-y-3 py-4">
             <header className="flex items-center justify-between">
               <h2 className="text-sm font-semibold text-foreground">Open alerts</h2>

--- a/components/case/CaseAlertsDrawer.tsx
+++ b/components/case/CaseAlertsDrawer.tsx
@@ -10,7 +10,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import type { AlertWithMatch } from "@/utils/alertsData";
 import { CaseStatusMenu } from "./CaseStatusMenu";
-import type { CaseDisplay } from "@/types/case";
+import type { CaseDisplay, CaseStatusUpdateHandler } from "@/types/case";
 import { getAlertDisplayDescription, getAlertDueDateInfo } from "@/utils/alertDisplay";
 
 interface CaseAlertsDrawerProps {
@@ -21,10 +21,7 @@ interface CaseAlertsDrawerProps {
   onResolveAlert?: (alert: AlertWithMatch) => void | Promise<void>;
   caseId?: string;
   caseStatus?: CaseDisplay["status"];
-  onUpdateStatus?: (
-    caseId: string,
-    status: CaseDisplay["status"],
-  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
+  onUpdateCaseStatus?: CaseStatusUpdateHandler;
 }
 
 export const CaseAlertsDrawer = memo(function CaseAlertsDrawer({
@@ -35,7 +32,7 @@ export const CaseAlertsDrawer = memo(function CaseAlertsDrawer({
   onResolveAlert,
   caseId,
   caseStatus,
-  onUpdateStatus,
+  onUpdateCaseStatus,
 }: CaseAlertsDrawerProps) {
   const handleResolve = useCallback(
     (alert: AlertWithMatch) => {
@@ -60,7 +57,7 @@ export const CaseAlertsDrawer = memo(function CaseAlertsDrawer({
   }, [alerts]);
 
   const totalAlerts = alerts.length;
-  const canUpdateStatus = Boolean(caseId && onUpdateStatus);
+  const canUpdateStatus = Boolean(caseId && onUpdateCaseStatus);
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -78,7 +75,7 @@ export const CaseAlertsDrawer = memo(function CaseAlertsDrawer({
                 <CaseStatusMenu
                   caseId={caseId}
                   status={caseStatus}
-                  onUpdateStatus={onUpdateStatus}
+                  onUpdateStatus={onUpdateCaseStatus}
                 />
               ) : null}
             </div>

--- a/components/case/CaseCard.tsx
+++ b/components/case/CaseCard.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "../ui/alert-dialog";
-import { CaseDisplay } from "../../types/case";
+import type { CaseDisplay, CaseStatusUpdateHandler } from "../../types/case";
 import { Eye, Edit, Trash2 } from "lucide-react";
 import { CaseStatusMenu } from "./CaseStatusMenu";
 import type { AlertWithMatch } from "../../utils/alertsData";
@@ -25,10 +25,7 @@ interface CaseCardProps {
   onEdit: (caseId: string) => void;
   onDelete: (caseId: string) => void;
   alerts?: AlertWithMatch[];
-  onUpdateStatus?: (
-    caseId: string,
-    status: CaseDisplay["status"],
-  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
+  onUpdateStatus?: CaseStatusUpdateHandler;
 }
 
 export function CaseCard({

--- a/components/case/CaseCard.tsx
+++ b/components/case/CaseCard.tsx
@@ -14,7 +14,7 @@ import {
 } from "../ui/alert-dialog";
 import { CaseDisplay } from "../../types/case";
 import { Eye, Edit, Trash2 } from "lucide-react";
-import { CaseStatusBadge } from "./CaseStatusBadge";
+import { CaseStatusMenu } from "./CaseStatusMenu";
 import type { AlertWithMatch } from "../../utils/alertsData";
 import { AlertBadge } from "@/components/alerts/AlertBadge";
 import { McnCopyControl } from "@/components/common/McnCopyControl";
@@ -25,9 +25,20 @@ interface CaseCardProps {
   onEdit: (caseId: string) => void;
   onDelete: (caseId: string) => void;
   alerts?: AlertWithMatch[];
+  onUpdateStatus?: (
+    caseId: string,
+    status: CaseDisplay["status"],
+  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
 }
 
-export function CaseCard({ case: caseData, onView, onEdit, onDelete, alerts = [] }: CaseCardProps) {
+export function CaseCard({
+  case: caseData,
+  onView,
+  onEdit,
+  onDelete,
+  alerts = [],
+  onUpdateStatus,
+}: CaseCardProps) {
   const formatDate = (value?: string) => {
     if (!value) {
       return "—";
@@ -60,7 +71,11 @@ export function CaseCard({ case: caseData, onView, onEdit, onDelete, alerts = []
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg">{caseData.name || 'Unnamed Case'}</CardTitle>
-          <CaseStatusBadge status={caseData.status} />
+          <CaseStatusMenu
+            caseId={caseData.id}
+            status={caseData.status}
+            onUpdateStatus={onUpdateStatus}
+          />
         </div>
         <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
           <McnCopyControl

--- a/components/case/CaseDetails.tsx
+++ b/components/case/CaseDetails.tsx
@@ -8,7 +8,7 @@ import { NotesSection } from "./NotesSection";
 import { CaseDisplay, CaseCategory, FinancialItem, NewNoteData } from "../../types/case";
 import { ArrowLeft, Edit2, Trash2, Landmark, Wallet, Receipt, BellRing } from "lucide-react";
 import { withDataErrorBoundary } from "../error/ErrorBoundaryHOC";
-import { CaseStatusBadge } from "./CaseStatusBadge";
+import { CaseStatusMenu } from "./CaseStatusMenu";
 import { Badge } from "../ui/badge";
 import { cn, interactiveHoverClasses } from "../ui/utils";
 import type { AlertWithMatch } from "../../utils/alertsData";
@@ -80,14 +80,6 @@ export function CaseDetails({
     };
   }, [alerts]);
 
-  const handleStatusChange = useCallback(
-    (status: CaseDisplay["status"]) => {
-      if (!onUpdateStatus) return;
-      onUpdateStatus(caseData.id, status);
-    },
-    [caseData.id, onUpdateStatus],
-  );
-
   const handleResolveAlert = useCallback(
     (alert: AlertWithMatch) => {
       onResolveAlert?.(alert);
@@ -115,9 +107,10 @@ export function CaseDetails({
                 <h1 className="text-xl font-bold text-foreground">
                   {caseData.name || 'Unnamed Case'}
                 </h1>
-                <CaseStatusBadge
+                <CaseStatusMenu
+                  caseId={caseData.id}
                   status={caseData.status}
-                  onStatusChange={onUpdateStatus ? handleStatusChange : undefined}
+                  onUpdateStatus={onUpdateStatus}
                 />
               </div>
               <McnCopyControl
@@ -286,6 +279,9 @@ export function CaseDetails({
           open={alertsDrawerOpen}
           onOpenChange={setAlertsDrawerOpen}
           caseName={caseData.name || "Unnamed Case"}
+          caseId={caseData.id}
+          caseStatus={caseData.status}
+          onUpdateStatus={onUpdateStatus}
           onResolveAlert={onResolveAlert ? handleResolveAlert : undefined}
         />
     </div>

--- a/components/case/CaseDetails.tsx
+++ b/components/case/CaseDetails.tsx
@@ -281,7 +281,7 @@ export function CaseDetails({
           caseName={caseData.name || "Unnamed Case"}
           caseId={caseData.id}
           caseStatus={caseData.status}
-          onUpdateStatus={onUpdateStatus}
+          onUpdateCaseStatus={onUpdateStatus}
           onResolveAlert={onResolveAlert ? handleResolveAlert : undefined}
         />
     </div>

--- a/components/case/CaseList.tsx
+++ b/components/case/CaseList.tsx
@@ -4,7 +4,7 @@ import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { CaseCard } from "./CaseCard";
 import { VirtualCaseList } from "../app/VirtualCaseList";
-import { CaseDisplay } from "../../types/case";
+import type { CaseDisplay, CaseStatusUpdateHandler } from "../../types/case";
 import { setupSampleData } from "../../utils/setupData";
 import { CaseAlertsDrawer } from "./CaseAlertsDrawer";
 import {
@@ -56,10 +56,7 @@ interface CaseListProps {
   alertsByCaseId?: Map<string, AlertWithMatch[]>;
   alerts?: AlertWithMatch[];
   onResolveAlert?: (alert: AlertWithMatch) => void | Promise<void>;
-  onUpdateCaseStatus?: (
-    caseId: string,
-    status: CaseDisplay["status"],
-  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
+  onUpdateCaseStatus?: CaseStatusUpdateHandler;
 }
 
 export function CaseList({

--- a/components/case/CaseList.tsx
+++ b/components/case/CaseList.tsx
@@ -431,7 +431,7 @@ export function CaseList({
         caseName={activeCase?.name || "Unnamed Case"}
         caseId={activeCase?.id}
         caseStatus={activeCase?.status}
-        onUpdateStatus={onUpdateCaseStatus}
+        onUpdateCaseStatus={onUpdateCaseStatus}
         onResolveAlert={onResolveAlert ? handleResolveAlert : undefined}
       />
     </div>

--- a/components/case/CaseList.tsx
+++ b/components/case/CaseList.tsx
@@ -56,6 +56,10 @@ interface CaseListProps {
   alertsByCaseId?: Map<string, AlertWithMatch[]>;
   alerts?: AlertWithMatch[];
   onResolveAlert?: (alert: AlertWithMatch) => void | Promise<void>;
+  onUpdateCaseStatus?: (
+    caseId: string,
+    status: CaseDisplay["status"],
+  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
 }
 
 export function CaseList({
@@ -69,6 +73,7 @@ export function CaseList({
   alertsByCaseId,
   alerts: _alerts,
   onResolveAlert,
+  onUpdateCaseStatus,
 }: CaseListProps) {
   const {
     viewMode,
@@ -358,6 +363,7 @@ export function CaseList({
           onDeleteCase={onDeleteCase}
           alertsByCaseId={matchedAlertsByCase}
           onOpenAlerts={handleOpenCaseAlerts}
+          onUpdateCaseStatus={onUpdateCaseStatus}
         />
       ) : shouldUseVirtual ? (
         <VirtualCaseList
@@ -366,6 +372,7 @@ export function CaseList({
           onEditCase={onEditCase}
           onDeleteCase={onDeleteCase}
           alertsByCaseId={openAlertsByCase}
+          onUpdateCaseStatus={onUpdateCaseStatus}
         />
       ) : (
         <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
@@ -376,6 +383,7 @@ export function CaseList({
               onView={onViewCase}
               onEdit={onEditCase}
               onDelete={onDeleteCase}
+              onUpdateStatus={onUpdateCaseStatus}
               alerts={openAlertsByCase.get(caseData.id) ?? []}
             />
           ))}
@@ -424,6 +432,9 @@ export function CaseList({
         open={alertsDrawerOpen}
         onOpenChange={handleAlertsDrawerOpenChange}
         caseName={activeCase?.name || "Unnamed Case"}
+        caseId={activeCase?.id}
+        caseStatus={activeCase?.status}
+        onUpdateStatus={onUpdateCaseStatus}
         onResolveAlert={onResolveAlert ? handleResolveAlert : undefined}
       />
     </div>

--- a/components/case/CaseStatusMenu.tsx
+++ b/components/case/CaseStatusMenu.tsx
@@ -1,0 +1,34 @@
+import { memo } from "react";
+import type { CaseDisplay } from "@/types/case";
+import { CaseStatusBadge } from "./CaseStatusBadge";
+import { useCaseStatusMenu } from "./useCaseStatusMenu";
+
+export interface CaseStatusMenuProps {
+  caseId: string;
+  status?: CaseDisplay["status"];
+  onUpdateStatus?: (
+    caseId: string,
+    status: CaseDisplay["status"],
+  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
+}
+
+export const CaseStatusMenu = memo(function CaseStatusMenu({
+  caseId,
+  status,
+  onUpdateStatus,
+}: CaseStatusMenuProps) {
+  const { status: effectiveStatus, handleStatusChange } = useCaseStatusMenu({
+    caseId,
+    status,
+    onUpdateStatus,
+  });
+
+  return (
+    <CaseStatusBadge
+      status={effectiveStatus}
+      onStatusChange={onUpdateStatus ? handleStatusChange : undefined}
+    />
+  );
+});
+
+export default CaseStatusMenu;

--- a/components/case/CaseStatusMenu.tsx
+++ b/components/case/CaseStatusMenu.tsx
@@ -1,15 +1,12 @@
 import { memo } from "react";
-import type { CaseDisplay } from "@/types/case";
+import type { CaseDisplay, CaseStatusUpdateHandler } from "@/types/case";
 import { CaseStatusBadge } from "./CaseStatusBadge";
 import { useCaseStatusMenu } from "./useCaseStatusMenu";
 
 export interface CaseStatusMenuProps {
   caseId: string;
   status?: CaseDisplay["status"];
-  onUpdateStatus?: (
-    caseId: string,
-    status: CaseDisplay["status"],
-  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
+  onUpdateStatus?: CaseStatusUpdateHandler;
 }
 
 export const CaseStatusMenu = memo(function CaseStatusMenu({

--- a/components/case/CaseTable.tsx
+++ b/components/case/CaseTable.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import type { CaseDisplay } from "@/types/case";
-import { CaseStatusBadge } from "./CaseStatusBadge";
+import { CaseStatusMenu } from "./CaseStatusMenu";
 import { ArrowDown, ArrowUp, ArrowUpDown, Eye, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import type { CaseListSortDirection, CaseListSortKey } from "@/hooks/useCaseListPreferences";
 import { filterOpenAlerts, type AlertWithMatch } from "@/utils/alertsData";
@@ -27,6 +27,10 @@ export interface CaseTableProps {
   onDeleteCase: (caseId: string) => void;
   alertsByCaseId?: Map<string, AlertWithMatch[]>;
   onOpenAlerts?: (caseId: string) => void;
+  onUpdateCaseStatus?: (
+    caseId: string,
+    status: CaseDisplay["status"],
+  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
 }
 
 const formatter = new Intl.DateTimeFormat(undefined, {
@@ -58,6 +62,7 @@ export const CaseTable = memo(function CaseTable({
   onDeleteCase,
   alertsByCaseId,
   onOpenAlerts,
+  onUpdateCaseStatus,
 }: CaseTableProps) {
   const hasCases = cases.length > 0;
 
@@ -254,7 +259,11 @@ export const CaseTable = memo(function CaseTable({
                 />
               </TableCell>
               <TableCell>
-                <CaseStatusBadge status={row.status} />
+                <CaseStatusMenu
+                  caseId={row.id}
+                  status={row.status}
+                  onUpdateStatus={onUpdateCaseStatus}
+                />
               </TableCell>
               <TableCell>
                 {row.alerts.length > 0 ? (

--- a/components/case/CaseTable.tsx
+++ b/components/case/CaseTable.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import type { CaseDisplay } from "@/types/case";
+import type { CaseDisplay, CaseStatusUpdateHandler } from "@/types/case";
 import { CaseStatusMenu } from "./CaseStatusMenu";
 import { ArrowDown, ArrowUp, ArrowUpDown, Eye, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import type { CaseListSortDirection, CaseListSortKey } from "@/hooks/useCaseListPreferences";
@@ -27,10 +27,7 @@ export interface CaseTableProps {
   onDeleteCase: (caseId: string) => void;
   alertsByCaseId?: Map<string, AlertWithMatch[]>;
   onOpenAlerts?: (caseId: string) => void;
-  onUpdateCaseStatus?: (
-    caseId: string,
-    status: CaseDisplay["status"],
-  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
+  onUpdateCaseStatus?: CaseStatusUpdateHandler;
 }
 
 const formatter = new Intl.DateTimeFormat(undefined, {

--- a/components/case/useCaseStatusMenu.ts
+++ b/components/case/useCaseStatusMenu.ts
@@ -32,6 +32,15 @@ function isAbortError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * Provides optimistic case-status selection with best-effort reconciliation.
+ *
+ * The hook keeps three views of status in sync (external, committed, optimistic),
+ * immediately reflects user choices, and gracefully reverts when the update handler
+ * returns `null`, throws (sync or async), or signals cancellation via `AbortError`.
+ * It also derives the available status options from the category configuration so
+ * consumers never need to duplicate that knowledge.
+ */
 export function useCaseStatusMenu({
   caseId,
   status,

--- a/components/case/useCaseStatusMenu.ts
+++ b/components/case/useCaseStatusMenu.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CaseDisplay } from "@/types/case";
+import { useCategoryConfig } from "@/contexts/CategoryConfigContext";
+
+interface UseCaseStatusMenuOptions {
+  caseId: string;
+  status?: CaseDisplay["status"];
+  onUpdateStatus?: (
+    caseId: string,
+    status: CaseDisplay["status"],
+  ) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
+}
+
+interface UseCaseStatusMenuResult {
+  status: CaseDisplay["status"];
+  isUpdating: boolean;
+  handleStatusChange: (status: CaseDisplay["status"]) => void;
+  availableStatuses: CaseDisplay["status"][];
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!error) return false;
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name === "AbortError";
+  }
+  if (error instanceof Error) {
+    return error.name === "AbortError";
+  }
+  if (typeof error === "object" && error !== null) {
+    const maybeName = (error as { name?: string }).name;
+    if (maybeName === "AbortError") {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function useCaseStatusMenu({
+  caseId,
+  status,
+  onUpdateStatus,
+}: UseCaseStatusMenuOptions): UseCaseStatusMenuResult {
+  const { config } = useCategoryConfig();
+  const fallbackStatus = useMemo<CaseDisplay["status"]>(() => {
+    return config.caseStatuses[0] ?? "Pending";
+  }, [config.caseStatuses]);
+
+  const availableStatuses = useMemo<CaseDisplay["status"][]>(() => {
+    return config.caseStatuses.length > 0 ? config.caseStatuses : [fallbackStatus];
+  }, [config.caseStatuses, fallbackStatus]);
+
+  const externalStatus = status ?? fallbackStatus;
+  const externalStatusRef = useRef<CaseDisplay["status"]>(externalStatus);
+  const committedStatusRef = useRef<CaseDisplay["status"]>(externalStatus);
+  const [optimisticStatus, setOptimisticStatus] = useState<CaseDisplay["status"]>(externalStatus);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const isUpdatingRef = useRef(false);
+
+  useEffect(() => {
+    if (externalStatusRef.current !== externalStatus) {
+      externalStatusRef.current = externalStatus;
+      committedStatusRef.current = externalStatus;
+      setOptimisticStatus(externalStatus);
+    }
+  }, [externalStatus]);
+
+  useEffect(() => {
+    isUpdatingRef.current = isUpdating;
+  }, [isUpdating]);
+
+  const handleStatusChange = useCallback(
+    (nextStatus: CaseDisplay["status"]) => {
+      if (!onUpdateStatus) {
+        return;
+      }
+
+      const committedStatus = committedStatusRef.current;
+      if (nextStatus === committedStatus) {
+        return;
+      }
+
+      if (isUpdatingRef.current) {
+        return;
+      }
+
+      setOptimisticStatus(nextStatus);
+      setIsUpdating(true);
+
+      Promise.resolve(onUpdateStatus(caseId, nextStatus))
+        .then(result => {
+          if (result && typeof result === "object" && "status" in result) {
+            const resolvedStatus = (result as CaseDisplay).status ?? nextStatus;
+            committedStatusRef.current = resolvedStatus;
+            setOptimisticStatus(resolvedStatus);
+            return;
+          }
+
+          if (result === null) {
+            committedStatusRef.current = committedStatus;
+            setOptimisticStatus(committedStatus);
+            return;
+          }
+
+          // Treat undefined/void as success; keep optimistic status until parent syncs.
+          committedStatusRef.current = nextStatus;
+        })
+        .catch(error => {
+          if (isAbortError(error)) {
+            committedStatusRef.current = committedStatus;
+            setOptimisticStatus(committedStatus);
+            return;
+          }
+
+          committedStatusRef.current = committedStatus;
+          setOptimisticStatus(committedStatus);
+        })
+        .finally(() => {
+          setIsUpdating(false);
+        });
+    },
+    [caseId, onUpdateStatus],
+  );
+
+  return {
+    status: optimisticStatus,
+    isUpdating,
+    handleStatusChange,
+    availableStatuses,
+  };
+}
+
+export default useCaseStatusMenu;

--- a/components/routing/ViewRenderer.tsx
+++ b/components/routing/ViewRenderer.tsx
@@ -121,6 +121,7 @@ export function ViewRenderer({
           onDeleteCase={handleDeleteCase}
           onNewCase={handleNewCase}
           onResolveAlert={handleResolveAlert}
+          onUpdateCaseStatus={handleUpdateCaseStatus}
         />
       );
 

--- a/types/case.ts
+++ b/types/case.ts
@@ -219,3 +219,8 @@ export interface CaseDisplay {
   caseRecord: CaseRecord;
   alerts?: AlertRecord[];
 }
+
+export type CaseStatusUpdateHandler = (
+  caseId: string,
+  status: CaseDisplay["status"],
+) => Promise<CaseDisplay | null> | CaseDisplay | null | void;

--- a/utils/safeNotifyFileStorageChange.ts
+++ b/utils/safeNotifyFileStorageChange.ts
@@ -1,0 +1,26 @@
+import { getFileService } from "./fileServiceProvider";
+import { createLogger } from "./logger";
+
+const logger = createLogger("FileStorageNotify");
+
+/**
+ * Best-effort notification helper for file storage mutations.
+ *
+ * The FileSystem Access API occasionally throws when the backing handle
+ * changes between operations. This helper centralises the try/catch so every
+ * mutation can opt-in without repeating boilerplate logging or guards.
+ */
+export function safeNotifyFileStorageChange(): void {
+  try {
+    const service = getFileService();
+    if (service && typeof service.notifyDataChange === "function") {
+      service.notifyDataChange();
+    }
+  } catch (error) {
+    logger.warn("Failed to notify file storage change", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export default safeNotifyFileStorageChange;


### PR DESCRIPTION
## Summary
- extract a reusable case status menu + hook that wrap CaseStatusBadge with optimistic updates and abort handling
- wire the shared status control through CaseDetails, CaseList table/grid/virtual cards, and CaseAlertsDrawer
- add targeted tests for CaseList and CaseAlertsDrawer status updates while preserving safe storage notifications

## Testing
- npm run test -- CaseList
- npm run test -- CaseAlertsDrawer

------
https://chatgpt.com/codex/tasks/task_e_68e09ede595c8332a59c78c2a480dae6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a CaseStatusMenu to update case status from lists, cards, details header, and alerts drawer.

* **Improvements**
  * Threaded onUpdateCaseStatus through list → table → virtual list → card → alerts drawer and view renderer.
  * Optimistic status updates with cancellation/error handling and UI synchronization.
  * Invoke storage-change notifier after status updates.

* **Types**
  * Added exported CaseStatusUpdateHandler type.

* **Tests**
  * Expanded tests for header, list/card flows, and alerts-driven status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->