### PR TITLE
feat: surface daily activity reporting

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import { useFileStorage, useFileStorageLifecycleSelectors } from "./contexts/Fil
 import { useDataManagerSafe } from "./contexts/DataManagerContext";
 import {
   useCaseManagement,
+  useCaseActivityLog,
   useConnectionFlow,
   useFinancialItemFlow,
   useNavigationFlow,
@@ -51,6 +52,16 @@ const AppContent = memo(function AppContent() {
     setError,
     setHasLoadedData,
   } = useCaseManagement();
+  const {
+    activityLog,
+    dailyReports: dailyActivityReports,
+    todayReport: todayActivityReport,
+    yesterdayReport: yesterdayActivityReport,
+    loading: activityLogLoading,
+    error: activityLogError,
+    refreshActivityLog,
+    getReportForDate,
+  } = useCaseActivityLog();
   const { setConfigFromFile } = useCategoryConfig();
   const [alertsIndex, setAlertsIndex] = useState<AlertsIndex>(() => createEmptyAlertsIndex());
   const resolvedAlertOverridesRef = useRef(
@@ -190,16 +201,46 @@ const AppContent = memo(function AppContent() {
     handleAddNote,
     handleEditNote,
     handleDeleteNote,
-    handleSaveNote,
+    handleSaveNote: baseHandleSaveNote,
     handleCancelNoteForm,
-    handleBatchUpdateNote,
-    handleBatchCreateNote,
+    handleBatchUpdateNote: baseHandleBatchUpdateNote,
+    handleBatchCreateNote: baseHandleBatchCreateNote,
   } = useNoteFlow({
     selectedCase: selectedCase ?? null,
     cases,
     setCases,
     setError,
   });
+
+  const handleSaveNote = useCallback(
+    async (noteData: NewNoteData) => {
+      await baseHandleSaveNote(noteData);
+      await refreshActivityLog();
+    },
+    [baseHandleSaveNote, refreshActivityLog],
+  );
+
+  const handleBatchUpdateNote = useCallback(
+    async (noteId: string, noteData: NewNoteData) => {
+      if (!baseHandleBatchUpdateNote) {
+        return;
+      }
+      await baseHandleBatchUpdateNote(noteId, noteData);
+      await refreshActivityLog();
+    },
+    [baseHandleBatchUpdateNote, refreshActivityLog],
+  );
+
+  const handleBatchCreateNote = useCallback(
+    async (noteData: NewNoteData) => {
+      if (!baseHandleBatchCreateNote) {
+        return;
+      }
+      await baseHandleBatchCreateNote(noteData);
+      await refreshActivityLog();
+    },
+    [baseHandleBatchCreateNote, refreshActivityLog],
+  );
 
   const applyAlertOverrides = useCallback(
     (index: AlertsIndex): AlertsIndex => {
@@ -317,8 +358,14 @@ const AppContent = memo(function AppContent() {
   }, [setCases]);
 
   const handleUpdateCaseStatus = useCallback(
-    (caseId: string, status: CaseDisplay["status"]) => updateCaseStatus(caseId, status),
-    [updateCaseStatus],
+    async (caseId: string, status: CaseDisplay["status"]) => {
+      const result = await updateCaseStatus(caseId, status);
+      if (result) {
+        await refreshActivityLog();
+      }
+      return result;
+    },
+    [refreshActivityLog, updateCaseStatus],
   );
 
   const handleDismissError = useCallback(() => {
@@ -587,20 +634,38 @@ const AppContent = memo(function AppContent() {
       onUpdateCaseStatus: handleUpdateCaseStatus,
       onResolveAlert: handleResolveAlert,
       onAlertsCsvImported: handleAlertsCsvImported,
+      activityLogState: {
+        activityLog,
+        dailyReports: dailyActivityReports,
+        todayReport: todayActivityReport,
+        yesterdayReport: yesterdayActivityReport,
+        loading: activityLogLoading,
+        error: activityLogError,
+        refreshActivityLog,
+        getReportForDate,
+      },
     }),
     [
+      activityLog,
+      activityLogError,
+      activityLogLoading,
+      alertsIndex,
       cases,
+      dailyActivityReports,
       editingCase,
       error,
+      getReportForDate,
       financialFlow,
       handleDismissError,
       handleUpdateCaseStatus,
       handleResolveAlert,
       handleAlertsCsvImported,
       noteFlow,
+      refreshActivityLog,
       selectedCase,
+      todayActivityReport,
+      yesterdayActivityReport,
       viewHandlers,
-      alertsIndex,
     ],
   );
 

--- a/components/app/CaseWorkspace.tsx
+++ b/components/app/CaseWorkspace.tsx
@@ -13,6 +13,7 @@ import type {
 import type { ItemFormState } from "../../hooks/useFinancialItemFlow";
 import type { useNotes } from "../../hooks/useNotes";
 import type { AlertsIndex, AlertWithMatch } from "../../utils/alertsData";
+import type { CaseActivityLogState } from "../../types/activityLog";
 
 const FinancialItemModal = lazy(() => import("../modals/FinancialItemModal"));
 const NoteModal = lazy(() => import("../modals/NoteModal"));
@@ -73,6 +74,7 @@ export interface CaseWorkspaceProps {
   onUpdateCaseStatus: (caseId: string, status: CaseDisplay["status"]) => Promise<CaseDisplay | null> | CaseDisplay | null | void;
   onResolveAlert?: (alert: AlertWithMatch) => Promise<void> | void;
   onAlertsCsvImported?: (index: AlertsIndex) => void;
+  activityLogState: CaseActivityLogState;
 }
 
 /**
@@ -94,6 +96,7 @@ export const CaseWorkspace = memo(function CaseWorkspace({
   onUpdateCaseStatus,
   onResolveAlert,
   onAlertsCsvImported,
+  activityLogState,
 }: CaseWorkspaceProps) {
   return (
     <AppNavigationShell {...navigation}>
@@ -135,6 +138,7 @@ export const CaseWorkspace = memo(function CaseWorkspace({
         handleUpdateCaseStatus={onUpdateCaseStatus}
         handleResolveAlert={onResolveAlert}
         onAlertsCsvImported={onAlertsCsvImported}
+        activityLogState={activityLogState}
       />
 
       {financialFlow.itemForm.isOpen && financialFlow.itemForm.category && selectedCase && (

--- a/components/app/Dashboard.tsx
+++ b/components/app/Dashboard.tsx
@@ -11,15 +11,18 @@ import { filterOpenAlerts, type AlertsIndex } from "../../utils/alertsData";
 import { getAlertClientName, getAlertDisplayDescription, getAlertDueDateInfo, getAlertMcn } from "@/utils/alertDisplay";
 import { UnlinkedAlertsDialog } from "@/components/alerts/UnlinkedAlertsDialog";
 import { McnCopyControl } from "@/components/common/McnCopyControl";
+import type { CaseActivityLogState } from "../../types/activityLog";
+import { getTopCasesForReport } from "../../utils/activityReport";
 
 interface DashboardProps {
   cases: CaseDisplay[];
   alerts: AlertsIndex;
+  activityLogState: CaseActivityLogState;
   onViewAllCases: () => void;
   onNewCase: () => void;
 }
 
-export function Dashboard({ cases, alerts, onViewAllCases, onNewCase }: DashboardProps) {
+export function Dashboard({ cases, alerts, activityLogState, onViewAllCases, onNewCase }: DashboardProps) {
   const { config } = useCategoryConfig();
 
   const validCases = useMemo(
@@ -119,6 +122,15 @@ export function Dashboard({ cases, alerts, onViewAllCases, onNewCase }: Dashboar
 
   const latestAlerts = useMemo(() => openAlerts.slice(0, 5), [openAlerts]);
 
+  const { todayReport, yesterdayReport, loading: activityLoading } = activityLogState;
+
+  const topTodayCases = useMemo(
+    () => (todayReport ? getTopCasesForReport(todayReport, 3) : []),
+    [todayReport],
+  );
+
+  const yesterdayTotals = yesterdayReport?.totals ?? null;
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -134,6 +146,69 @@ export function Dashboard({ cases, alerts, onViewAllCases, onNewCase }: Dashboar
           </Button>
         </div>
       </div>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>Today&apos;s Case Activity</CardTitle>
+            <CardDescription>Automatic log of status changes and new notes</CardDescription>
+          </div>
+          {yesterdayTotals && (
+            <div className="text-xs text-muted-foreground">
+              Yesterday: {yesterdayTotals.total} total · {yesterdayTotals.statusChanges} status · {yesterdayTotals.notesAdded} notes
+            </div>
+          )}
+        </CardHeader>
+        <CardContent>
+          {activityLogState.error && !activityLoading && (
+            <p className="text-sm text-destructive mb-2">
+              Unable to refresh activity log: {activityLogState.error}
+            </p>
+          )}
+          {activityLoading ? (
+            <p className="text-sm text-muted-foreground">Loading recent activity…</p>
+          ) : todayReport && todayReport.totals.total > 0 ? (
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div className="rounded-lg border border-border bg-muted/40 p-4">
+                  <div className="text-xs uppercase text-muted-foreground">Total entries</div>
+                  <div className="text-2xl font-semibold text-foreground">{todayReport.totals.total}</div>
+                </div>
+                <div className="rounded-lg border border-border bg-muted/40 p-4">
+                  <div className="text-xs uppercase text-muted-foreground">Status changes</div>
+                  <div className="text-2xl font-semibold text-foreground">{todayReport.totals.statusChanges}</div>
+                </div>
+                <div className="rounded-lg border border-border bg-muted/40 p-4">
+                  <div className="text-xs uppercase text-muted-foreground">Notes added</div>
+                  <div className="text-2xl font-semibold text-foreground">{todayReport.totals.notesAdded}</div>
+                </div>
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-muted-foreground mb-2">Top cases touched today</h3>
+                {topTodayCases.length > 0 ? (
+                  <ul className="space-y-1 text-sm text-foreground">
+                    {topTodayCases.map(caseSummary => {
+                      const total = caseSummary.statusChanges + caseSummary.notesAdded;
+                      return (
+                        <li key={caseSummary.caseId} className="flex items-center justify-between rounded-md border border-border/60 bg-background/80 px-3 py-2">
+                          <span className="font-medium">{caseSummary.caseName}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {total} entr{total === 1 ? "y" : "ies"} · {caseSummary.statusChanges} status · {caseSummary.notesAdded} notes
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No case activity recorded yet today.</p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No case activity recorded yet today.</p>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/components/routing/ViewRenderer.tsx
+++ b/components/routing/ViewRenderer.tsx
@@ -1,6 +1,7 @@
 import { CaseDisplay, NewPersonData, NewCaseRecordData } from "../../types/case";
 import { AppView } from "../../types/view";
 import type { AlertsIndex, AlertWithMatch } from "../../utils/alertsData";
+import type { CaseActivityLogState } from "../../types/activityLog";
 
 // Direct imports for high-turnover components - no lazy loading for snappiness
 import Dashboard from "../app/Dashboard";
@@ -16,10 +17,11 @@ interface ViewRendererProps {
   currentView: View;
   selectedCase: CaseDisplay | null | undefined;
   editingCase: CaseDisplay | null;
-  
+
   // Data props
   cases: CaseDisplay[];
   alerts: AlertsIndex;
+  activityLogState: CaseActivityLogState;
   
   // Navigation handlers
   handleViewCase: (caseId: string) => void;
@@ -68,10 +70,11 @@ export function ViewRenderer({
   currentView,
   selectedCase,
   editingCase,
-  
+
   // Data props
   cases,
   alerts,
+  activityLogState,
   
   // Navigation handlers
   handleViewCase,
@@ -104,6 +107,7 @@ export function ViewRenderer({
         <Dashboard
           cases={cases}
           alerts={alerts}
+          activityLogState={activityLogState}
           onViewAllCases={handleBackToList}
           onNewCase={handleNewCase}
         />
@@ -129,6 +133,7 @@ export function ViewRenderer({
       return (
         <Settings
           cases={cases}
+          activityLogState={activityLogState}
           onDataPurged={handleDataPurged}
           onAlertsCsvImported={onAlertsCsvImported}
         />

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -6,6 +6,9 @@
 // Case management operations
 export { useCaseManagement } from './useCaseManagement';
 
+// Case activity log
+export { useCaseActivityLog } from './useCaseActivityLog';
+
 // File system connection flow
 export { useConnectionFlow } from './useConnectionFlow';
 

--- a/hooks/useCaseActivityLog.ts
+++ b/hooks/useCaseActivityLog.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useDataManagerSafe } from "../contexts/DataManagerContext";
+import type { CaseActivityEntry, DailyActivityReport } from "../types/activityLog";
+import {
+  generateDailyActivityReport,
+  groupActivityEntriesByDate,
+  toActivityDateKey,
+} from "../utils/activityReport";
+
+interface UseCaseActivityLogResult {
+  activityLog: CaseActivityEntry[];
+  dailyReports: DailyActivityReport[];
+  todayReport: DailyActivityReport | null;
+  yesterdayReport: DailyActivityReport | null;
+  loading: boolean;
+  error: string | null;
+  refreshActivityLog: () => Promise<void>;
+  getReportForDate: (date: string | Date) => DailyActivityReport;
+}
+
+export function useCaseActivityLog(): UseCaseActivityLogResult {
+  const dataManager = useDataManagerSafe();
+  const [activityLog, setActivityLog] = useState<CaseActivityEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshActivityLog = useCallback(async () => {
+    if (!dataManager) {
+      setActivityLog([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const entries = await dataManager.getActivityLog();
+      setActivityLog(entries);
+      setError(null);
+    } catch (err) {
+      console.error("Failed to load activity log", err);
+      setError(err instanceof Error ? err.message : "Failed to load activity log");
+    } finally {
+      setLoading(false);
+    }
+  }, [dataManager]);
+
+  useEffect(() => {
+    refreshActivityLog().catch(err => {
+      console.error("Failed to refresh activity log", err);
+    });
+  }, [refreshActivityLog]);
+
+  const groupedByDate = useMemo(() => groupActivityEntriesByDate(activityLog), [activityLog]);
+
+  const dailyReports = useMemo(() => {
+    return Array.from(groupedByDate.entries())
+      .map(([dateKey, entriesForDate]) => generateDailyActivityReport(entriesForDate, dateKey))
+      .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+  }, [groupedByDate]);
+
+  const todayReport = useMemo(() => {
+    const todayKey = toActivityDateKey(new Date());
+    return dailyReports.find(report => report.date === todayKey) ?? null;
+  }, [dailyReports]);
+
+  const yesterdayReport = useMemo(() => {
+    const yesterday = new Date();
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    const yesterdayKey = toActivityDateKey(yesterday);
+    return dailyReports.find(report => report.date === yesterdayKey) ?? null;
+  }, [dailyReports]);
+
+  const getReportForDate = useCallback(
+    (date: string | Date) => generateDailyActivityReport(activityLog, date),
+    [activityLog],
+  );
+
+  return {
+    activityLog,
+    dailyReports,
+    todayReport,
+    yesterdayReport,
+    loading,
+    error,
+    refreshActivityLog,
+    getReportForDate,
+  };
+}

--- a/types/activityLog.ts
+++ b/types/activityLog.ts
@@ -1,0 +1,61 @@
+export type CaseActivityType = "status-change" | "note-added";
+
+interface CaseActivityBase {
+  id: string;
+  timestamp: string;
+  caseId: string;
+  caseName: string;
+  caseMcn?: string | null;
+}
+
+export interface CaseStatusChangeActivity extends CaseActivityBase {
+  type: "status-change";
+  payload: {
+    fromStatus?: string | null;
+    toStatus: string;
+  };
+}
+
+export interface CaseNoteAddedActivity extends CaseActivityBase {
+  type: "note-added";
+  payload: {
+    noteId: string;
+    category: string;
+    preview: string;
+  };
+}
+
+export type CaseActivityEntry = CaseStatusChangeActivity | CaseNoteAddedActivity;
+
+export interface DailyCaseActivityBreakdown {
+  caseId: string;
+  caseName: string;
+  caseMcn?: string | null;
+  statusChanges: number;
+  notesAdded: number;
+  entries: CaseActivityEntry[];
+}
+
+export interface DailyActivityReport {
+  date: string;
+  totals: {
+    total: number;
+    statusChanges: number;
+    notesAdded: number;
+  };
+  entries: CaseActivityEntry[];
+  cases: DailyCaseActivityBreakdown[];
+}
+
+export type ActivityReportFormat = "json" | "csv" | "txt";
+
+export interface CaseActivityLogState {
+  activityLog: CaseActivityEntry[];
+  dailyReports: DailyActivityReport[];
+  todayReport: DailyActivityReport | null;
+  yesterdayReport: DailyActivityReport | null;
+  loading: boolean;
+  error: string | null;
+  refreshActivityLog: () => Promise<void>;
+  getReportForDate: (date: string | Date) => DailyActivityReport;
+}

--- a/utils/activityReport.ts
+++ b/utils/activityReport.ts
@@ -1,0 +1,201 @@
+import {
+  ActivityReportFormat,
+  CaseActivityEntry,
+  DailyActivityReport,
+  DailyCaseActivityBreakdown,
+} from "../types/activityLog";
+
+function parseDateInput(targetDate: string | Date): Date {
+  if (targetDate instanceof Date) {
+    return new Date(targetDate.getTime());
+  }
+
+  return new Date(targetDate);
+}
+
+export function toActivityDateKey(targetDate: string | Date): string {
+  const date = parseDateInput(targetDate);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Invalid date provided to toActivityDateKey");
+  }
+
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+export function filterActivityEntriesByDate(
+  entries: CaseActivityEntry[],
+  targetDate: string | Date,
+): CaseActivityEntry[] {
+  const dateKey = toActivityDateKey(targetDate);
+
+  return entries.filter(entry => toActivityDateKey(entry.timestamp) === dateKey);
+}
+
+export function groupActivityEntriesByDate(
+  entries: CaseActivityEntry[],
+): Map<string, CaseActivityEntry[]> {
+  return entries.reduce<Map<string, CaseActivityEntry[]>>((map, entry) => {
+    const key = toActivityDateKey(entry.timestamp);
+    const bucket = map.get(key) ?? [];
+    bucket.push(entry);
+    map.set(key, bucket);
+    return map;
+  }, new Map());
+}
+
+function summarizeCaseEntries(entries: CaseActivityEntry[]): DailyCaseActivityBreakdown[] {
+  const caseMap = new Map<string, DailyCaseActivityBreakdown>();
+
+  for (const entry of entries) {
+    const existing = caseMap.get(entry.caseId);
+    if (!existing) {
+      caseMap.set(entry.caseId, {
+        caseId: entry.caseId,
+        caseName: entry.caseName,
+        caseMcn: entry.caseMcn,
+        statusChanges: entry.type === "status-change" ? 1 : 0,
+        notesAdded: entry.type === "note-added" ? 1 : 0,
+        entries: [entry],
+      });
+      continue;
+    }
+
+    if (entry.type === "status-change") {
+      existing.statusChanges += 1;
+    } else if (entry.type === "note-added") {
+      existing.notesAdded += 1;
+    }
+    existing.entries.push(entry);
+  }
+
+  return Array.from(caseMap.values()).sort((a, b) => {
+    const aTotal = a.statusChanges + a.notesAdded;
+    const bTotal = b.statusChanges + b.notesAdded;
+    if (bTotal !== aTotal) {
+      return bTotal - aTotal;
+    }
+    return a.caseName.localeCompare(b.caseName);
+  });
+}
+
+export function generateDailyActivityReport(
+  entries: CaseActivityEntry[],
+  targetDate: string | Date,
+): DailyActivityReport {
+  const filteredEntries = filterActivityEntriesByDate(entries, targetDate).sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+  );
+
+  const statusChanges = filteredEntries.filter(entry => entry.type === "status-change").length;
+  const notesAdded = filteredEntries.filter(entry => entry.type === "note-added").length;
+
+  return {
+    date: toActivityDateKey(targetDate),
+    totals: {
+      total: filteredEntries.length,
+      statusChanges,
+      notesAdded,
+    },
+    entries: filteredEntries,
+    cases: summarizeCaseEntries(filteredEntries),
+  };
+}
+
+export function getTopCasesForReport(
+  report: DailyActivityReport,
+  limit = 3,
+): DailyCaseActivityBreakdown[] {
+  return report.cases.slice(0, Math.max(0, limit));
+}
+
+function getEntryDetail(entry: CaseActivityEntry): string {
+  if (entry.type === "status-change") {
+    const fromStatus = entry.payload.fromStatus ?? "Unknown";
+    const toStatus = entry.payload.toStatus;
+    return `Status changed from ${fromStatus} to ${toStatus}`;
+  }
+
+  const preview = entry.payload.preview.replace(/\s+/g, " ").trim();
+  const snippet = preview.length > 80 ? `${preview.slice(0, 77)}…` : preview;
+  return `Note added (${entry.payload.category}) – ${snippet}`;
+}
+
+function formatCsv(report: DailyActivityReport): string {
+  const header = ["Timestamp", "Case", "MCN", "Type", "Detail"].join(",");
+  const rows = report.entries.map(entry => {
+    const values = [
+      new Date(entry.timestamp).toISOString(),
+      entry.caseName.replace(/"/g, '""'),
+      entry.caseMcn ? String(entry.caseMcn).replace(/"/g, '""') : "",
+      entry.type,
+      getEntryDetail(entry).replace(/"/g, '""'),
+    ];
+
+    return values.map(value => `"${value}"`).join(",");
+  });
+
+  return [header, ...rows].join("\n");
+}
+
+function formatTxt(report: DailyActivityReport): string {
+  const lines: string[] = [];
+  lines.push(`Activity Report for ${report.date}`);
+  lines.push("============================");
+  lines.push(`Total entries: ${report.totals.total}`);
+  lines.push(`Status changes: ${report.totals.statusChanges}`);
+  lines.push(`Notes added: ${report.totals.notesAdded}`);
+  lines.push("");
+  lines.push("Top cases:");
+
+  const topCases = getTopCasesForReport(report, 5);
+  if (topCases.length === 0) {
+    lines.push("  No case activity recorded.");
+  } else {
+    for (const breakdown of topCases) {
+      const total = breakdown.statusChanges + breakdown.notesAdded;
+      lines.push(
+        `  • ${breakdown.caseName} (${breakdown.caseMcn ?? "MCN N/A"}) – ${total} entr${
+          total === 1 ? "y" : "ies"
+        }`,
+      );
+    }
+  }
+
+  if (report.entries.length > 0) {
+    lines.push("");
+    lines.push("Entries:");
+    for (const entry of report.entries) {
+      lines.push(
+        `  - [${new Date(entry.timestamp).toLocaleTimeString(undefined, {
+          hour: "2-digit",
+          minute: "2-digit",
+        })}] ${entry.caseName}: ${getEntryDetail(entry)}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatJson(report: DailyActivityReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function serializeDailyActivityReport(
+  report: DailyActivityReport,
+  format: ActivityReportFormat,
+): string {
+  switch (format) {
+    case "csv":
+      return formatCsv(report);
+    case "txt":
+      return formatTxt(report);
+    case "json":
+    default:
+      return formatJson(report);
+  }
+}


### PR DESCRIPTION
## Summary
- persist structured case activity entries for status changes and notes while exposing retrieval APIs
- add hook and utilities to build daily activity reports for dashboard and settings views
- surface today/yesterday activity on the dashboard and multi-format exports within settings

## Testing
- npm test -- __tests__/DataManager.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e20d86a6708332ba4c59d758d5ab8c