### PR TITLE
feat: split advanced alert criteria into include/exclude groups

### DIFF
--- a/__tests__/hooks/useAdvancedAlertFilter.test.ts
+++ b/__tests__/hooks/useAdvancedAlertFilter.test.ts
@@ -102,6 +102,52 @@ describe("useAdvancedAlertFilter", () => {
     expect(result.current.filter.criteria).toHaveLength(0);
   });
 
+  it("adds exclude criterion with negate forced true", () => {
+    const { result } = renderHook(() => useAdvancedAlertFilter());
+
+    act(() => {
+      result.current.addExcludeCriterion({
+        id: "exclude-1",
+        field: "description",
+        operator: "contains",
+        value: "mail",
+        negate: false,
+      });
+    });
+
+    expect(result.current.filter.criteria).toHaveLength(1);
+    expect(result.current.filter.criteria[0]).toEqual(
+      expect.objectContaining({
+        id: "exclude-1",
+        negate: true,
+      }),
+    );
+  });
+
+  it("partitions include and exclude criteria", () => {
+    const { result } = renderHook(() => useAdvancedAlertFilter());
+
+    act(() => {
+      result.current.addCriterion({
+        id: "include-1",
+        field: "description",
+        operator: "contains",
+        value: "AVS",
+        negate: false,
+      });
+      result.current.addExcludeCriterion({
+        id: "exclude-1",
+        field: "status",
+        operator: "equals",
+        value: "resolved",
+        negate: false,
+      });
+    });
+
+    expect(result.current.includeCriteria.map((item) => item.id)).toEqual(["include-1"]);
+    expect(result.current.excludeCriteria.map((item) => item.id)).toEqual(["exclude-1"]);
+  });
+
   it("sets top-level logic", () => {
     const { result } = renderHook(() => useAdvancedAlertFilter());
 

--- a/domain/alerts/filtering.ts
+++ b/domain/alerts/filtering.ts
@@ -286,6 +286,20 @@ export function isAdvancedFilterActive(filter: AdvancedAlertFilter): boolean {
   return filter.criteria.some(hasUsableValue);
 }
 
+export function partitionCriteria(criteria: FilterCriterion[]): {
+  include: FilterCriterion[];
+  exclude: FilterCriterion[];
+} {
+  const include: FilterCriterion[] = [];
+  const exclude: FilterCriterion[] = [];
+
+  for (const criterion of criteria) {
+    (criterion.negate ? exclude : include).push(criterion);
+  }
+
+  return { include, exclude };
+}
+
 export function createEmptyFilterCriterion(field: FilterableField = "description"): FilterCriterion {
   const fieldType = getFieldType(field);
   let operator: FilterOperator = "contains";

--- a/domain/alerts/index.ts
+++ b/domain/alerts/index.ts
@@ -43,6 +43,7 @@ export {
   evaluateCriterion,
   applyAdvancedFilter,
   isAdvancedFilterActive,
+  partitionCriteria,
   createEmptyFilterCriterion,
   createEmptyAdvancedFilter,
   getOperatorsForField,

--- a/hooks/useAdvancedAlertFilter.ts
+++ b/hooks/useAdvancedAlertFilter.ts
@@ -3,6 +3,7 @@ import { createLocalStorageAdapter } from "@/utils/localStorage";
 import {
   createEmptyAdvancedFilter,
   isAdvancedFilterActive,
+  partitionCriteria,
   deserializeAdvancedFilter,
   type AdvancedAlertFilter,
   type FilterCriterion,
@@ -13,7 +14,10 @@ import { useDebouncedSave } from "./useDebouncedSave";
 
 interface UseAdvancedAlertFilterResult {
   filter: AdvancedAlertFilter;
+  includeCriteria: FilterCriterion[];
+  excludeCriteria: FilterCriterion[];
   addCriterion: (criterion?: FilterCriterion) => void;
+  addExcludeCriterion: (criterion?: FilterCriterion) => void;
   updateCriterion: (id: string, updates: Partial<Omit<FilterCriterion, "id">>) => void;
   removeCriterion: (id: string) => void;
   toggleNegate: (id: string) => void;
@@ -55,6 +59,10 @@ export function useAdvancedAlertFilter(): UseAdvancedAlertFilterResult {
     setFilter((prev) => advancedAlertFilterService.addCriterion(prev, item));
   }, []);
 
+  const addExcludeCriterion = useCallback((item?: FilterCriterion) => {
+    setFilter((prev) => advancedAlertFilterService.addExcludeCriterion(prev, item));
+  }, []);
+
   const updateCriterion = useCallback((id: string, updates: Partial<Omit<FilterCriterion, "id">>) => {
     setFilter((prev) => advancedAlertFilterService.updateCriterion(prev, id, updates));
   }, []);
@@ -77,10 +85,17 @@ export function useAdvancedAlertFilter(): UseAdvancedAlertFilterResult {
   }, []);
 
   const hasActiveAdvancedFilters = useMemo(() => isAdvancedFilterActive(filter), [filter]);
+  const { include: includeCriteria, exclude: excludeCriteria } = useMemo(
+    () => partitionCriteria(filter.criteria),
+    [filter.criteria],
+  );
 
   return {
     filter,
+    includeCriteria,
+    excludeCriteria,
     addCriterion,
+    addExcludeCriterion,
     updateCriterion,
     removeCriterion,
     toggleNegate,

--- a/utils/services/AdvancedAlertFilterService.ts
+++ b/utils/services/AdvancedAlertFilterService.ts
@@ -12,6 +12,14 @@ export class AdvancedAlertFilterService {
     };
   }
 
+  addExcludeCriterion(filter: AdvancedAlertFilter, criterion?: FilterCriterion): AdvancedAlertFilter {
+    const baseCriterion = criterion ?? createEmptyFilterCriterion();
+    return {
+      ...filter,
+      criteria: [...filter.criteria, { ...baseCriterion, negate: true }],
+    };
+  }
+
   updateCriterion(
     filter: AdvancedAlertFilter,
     id: string,


### PR DESCRIPTION
## Summary
- add partitionCriteria in alerts domain and export it
- add addExcludeCriterion in AdvancedAlertFilterService
- extend useAdvancedAlertFilter with addExcludeCriterion, includeCriteria, and excludeCriteria
- restructure advanced alert criteria UI in CaseFiltersDialog into Include criteria and Exclude criteria sections
- remove per-criterion Exclude matching alerts checkbox and keep underlying negate model unchanged
- add tests for partitioning and hook include/exclude behavior

## Why
Align advanced alert criteria UX with the existing include/exclude status filter pattern while preserving filter semantics and persisted data format.

## Validation
- npm run build
- npm run lint
- npm run test:run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced alert filters now display separate "Include" and "Exclude" sections, allowing users to manage inclusion and exclusion criteria independently with dedicated add buttons for each section.

* **Improvements**
  * Simplified advanced filter UI by removing redundant negate toggles within individual filter criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->