### PR TITLE
Core domain namespace

### DIFF
--- a/hooks/usePositionAssignmentsImport.ts
+++ b/hooks/usePositionAssignmentsImport.ts
@@ -14,7 +14,7 @@
 import { useCallback, useMemo, useRef, useState, type ChangeEvent, type RefObject } from "react";
 import { toast } from "sonner";
 import { useDataManagerSafe } from "@/contexts/DataManagerContext";
-import type { CaseStatus, StoredCase } from "@/types/case";
+import type { StoredCase } from "@/types/case";
 import type { CategoryConfig } from "@/types/categoryConfig";
 import {
   parsePositionAssignments,
@@ -361,11 +361,22 @@ export function usePositionAssignmentsImport({
           ]);
         }
 
+        const knownStatusNames = new Set([
+          ...categoryConfig.caseStatuses.map(s => s.name),
+          ...statusImportPlan.newStatuses.map(s => s.name),
+        ]);
+
         for (const [status, caseIds] of statusImportPlan.statusUpdatesByStatus) {
-          await dataManager.updateCasesStatus(caseIds, status as CaseStatus);
+          const canonicalStatus = [...knownStatusNames].find(n => n.toLowerCase() === status.toLowerCase());
+          if (canonicalStatus) {
+            await dataManager.updateCasesStatus(caseIds, canonicalStatus as StoredCase["status"]);
+          } else {
+            logger.warn("Skipping status update for unconfigured status", { status, caseCount: caseIds.length });
+          }
         }
 
         statusUpdatedCount = statusImportPlan.updatedCaseCount;
+        onCasesUpdated?.();
       }
 
       // ---- 2. Flag unmatched cases for archival ----
@@ -374,9 +385,8 @@ export function usePositionAssignmentsImport({
           Array.from(importState.selectedCaseIds)
         );
         archivalMarkedCount = archivalResult.markedCount;
+        onCasesUpdated?.();
       }
-
-      onCasesUpdated?.();
 
       // Build a combined toast message
       const parts: string[] = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses two issues identified in PR #121 related to position import:

1.  **Validates imported statuses:** Prevents unsafe casting of arbitrary strings to `CaseStatus` by validating imported statuses against configured statuses before updating. Unconfigured statuses are now skipped with a warning.
2.  **Ensures UI refresh on partial success:** Calls `onCasesUpdated` after each successful operation (status updates, archival flagging) to ensure the UI refreshes even if subsequent operations fail.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 📝 Documentation (changes to docs only)
- [ ] 🧪 Test (adding or updating tests)

## Checklist

- [ ] Tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Code follows existing patterns (see `.github/copilot-instructions.md`)
- [ ] No console errors or warnings in browser

## Related Issues

Fixes https://github.com/Skigim/CMSNext/pull/121#discussion_r2880449931
Fixes https://github.com/Skigim/CMSNext/pull/121#discussion_r2880449930

## Screenshots (if applicable)

---
<p><a href="https://cursor.com/agents/bc-f894db17-7e4e-4d93-8e8b-ecaa82c0e0b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f894db17-7e4e-4d93-8e8b-ecaa82c0e0b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->