### PR TITLE
fix: Add missing Apt field changes

### DIFF
--- a/__tests__/components/case/IntakeFormView.test.tsx
+++ b/__tests__/components/case/IntakeFormView.test.tsx
@@ -279,6 +279,18 @@ describe("IntakeFormView", () => {
         zip: "",
       });
     });
+
+    it("has no accessibility violations on the contact step", async () => {
+      // ARRANGE
+      withHookState(createStepState(1));
+
+      // ACT
+      const { container } = renderIntakeFormView();
+      const results = await axe(container);
+
+      // ASSERT
+      expect(results).toHaveNoViolations();
+    });
   });
 
   describe("focus management", () => {

--- a/components/case/IntakeFormView.tsx
+++ b/components/case/IntakeFormView.tsx
@@ -414,14 +414,25 @@ function ContactStep({ formData, onChange }: Readonly<ContactStepProps>) {
 
         {!formData.mailingAddress.sameAsPhysical && (
           <>
-            <div className="space-y-1.5">
-              <Label htmlFor="intake-mailStreet">Street</Label>
-              <Input
-                id="intake-mailStreet"
-                value={formData.mailingAddress.street ?? ""}
-                onChange={(e) => handleMailingChange("street", e.target.value)}
-                placeholder="123 Main St"
-              />
+            <div className="grid grid-cols-[1fr_auto] gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="intake-mailStreet">Street</Label>
+                <Input
+                  id="intake-mailStreet"
+                  value={formData.mailingAddress.street ?? ""}
+                  onChange={(e) => handleMailingChange("street", e.target.value)}
+                  placeholder="123 Main St"
+                />
+              </div>
+              <div className="w-24 space-y-1.5">
+                <Label htmlFor="intake-mailApt">Apt</Label>
+                <Input
+                  id="intake-mailApt"
+                  value={formData.mailingAddress.apt ?? ""}
+                  onChange={(e) => handleMailingChange("apt", e.target.value)}
+                  placeholder="Apt"
+                />
+              </div>
             </div>
             <div className="grid grid-cols-3 gap-3">
               <div className="col-span-1 space-y-1.5">


### PR DESCRIPTION
Recovered local commit for Apt fields that was missed in PR #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The intake form's contact step mailing address section now includes a new dedicated apartment/unit input field, displayed alongside the street address field in a two-column grid layout.

* **Tests**
  * Added automated accessibility compliance checking tests for the intake form's contact step to ensure adherence to web accessibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->