### PR TITLE
feat: reopen completed intake on summary step

### DIFF
--- a/__tests__/hooks/useIntakeWorkflow.test.ts
+++ b/__tests__/hooks/useIntakeWorkflow.test.ts
@@ -126,6 +126,18 @@ describe("useIntakeWorkflow", () => {
       expect(result.current.currentStep).toBe(0);
     });
 
+    it("starts on the summary step when editing a legacy case without intakeCompleted", () => {
+      // Arrange
+      const existingCase = createMockStoredCase();
+      delete (existingCase.caseRecord as { intakeCompleted?: boolean }).intakeCompleted;
+
+      // Act
+      const { result } = renderIntakeHook({ existingCase });
+
+      // Assert
+      expect(result.current.currentStep).toBe(REVIEW_STEP_INDEX);
+    });
+
     it("has step 0 in visited set", () => {
       const { result } = renderIntakeHook();
       expect(result.current.visitedSteps.has(0)).toBe(true);

--- a/hooks/useIntakeWorkflow.ts
+++ b/hooks/useIntakeWorkflow.ts
@@ -24,6 +24,7 @@ import { dateInputValueToISO, normalizePhoneNumber } from "@/domain/common";
 import { useDataManagerSafe } from "../contexts/DataManagerContext";
 import { useCategoryConfig } from "../contexts/CategoryConfigContext";
 import {
+  caseNeedsIntake,
   createBlankHouseholdMemberData,
   createCaseRecordData,
   isHouseholdMemberPopulated,
@@ -58,7 +59,7 @@ function createInitialVisitedSteps(existingCase?: StoredCase): Set<number> {
 }
 
 function createInitialCurrentStep(existingCase?: StoredCase): number {
-  if (existingCase?.caseRecord.intakeCompleted) {
+  if (existingCase && !caseNeedsIntake(existingCase)) {
     return INTAKE_STEPS.length - 1;
   }
 


### PR DESCRIPTION
## Summary
- reopen IntakeFormView on the summary step when returning to a completed intake case
- add hook coverage for completed and incomplete intake edit flows
- sync the feature branch with the VRGeneratorModal test-flake fix already merged to main

## Validation
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Intake workflow now resumes users at the review/summary step for previously completed or legacy cases (missing completion flag).
  * New intakes still start at the beginning.
  * After saving edits, the workflow reset returns users to the review/summary step rather than the first step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->