### PR TITLE
Adds ctrl+enter helper to pinned cases modal

### DIFF
--- a/__tests__/components/common/PinButton.test.tsx
+++ b/__tests__/components/common/PinButton.test.tsx
@@ -13,14 +13,14 @@ vi.mock("@/hooks/usePinnedCases", () => ({
 
 const usePinnedCasesMock = vi.mocked(usePinnedCases);
 
-type PinnedCasesHookResult = ReturnType<typeof usePinnedCases>;
-type PinnedCasesHookOverrides = Partial<PinnedCasesHookResult>;
-type KeyboardModifier = Pick<KeyboardEvent, "ctrlKey" | "metaKey">;
-type PinButtonProps = Partial<ComponentProps<typeof PinButton>>;
+type PinnedCasesHookMock = ReturnType<typeof usePinnedCases>;
+type PinnedCasesHookMockOverrides = Partial<PinnedCasesHookMock>;
+type SubmitKeyModifier = Pick<KeyboardEvent, "ctrlKey" | "metaKey">;
+type PinButtonTestProps = Partial<ComponentProps<typeof PinButton>>;
 
 function createPinnedCasesHookResult(
-  overrides: PinnedCasesHookOverrides = {},
-): PinnedCasesHookResult {
+  overrides: PinnedCasesHookMockOverrides = {},
+): PinnedCasesHookMock {
   return {
     pinnedCaseIds: [],
     pin: vi.fn(),
@@ -36,13 +36,13 @@ function createPinnedCasesHookResult(
   };
 }
 
-function renderPinButton(props: PinButtonProps = {}) {
+function renderPinButton(props: PinButtonTestProps = {}) {
   return render(<PinButton caseId="case-1" caseName="Case One" {...props} />);
 }
 
 function setupPinButton(
-  hookOverrides: PinnedCasesHookOverrides = {},
-  props: PinButtonProps = {},
+  hookOverrides: PinnedCasesHookMockOverrides = {},
+  props: PinButtonTestProps = {},
 ) {
   const hookResult = createPinnedCasesHookResult(hookOverrides);
   usePinnedCasesMock.mockReturnValue(hookResult);
@@ -53,9 +53,9 @@ function setupPinButton(
   };
 }
 
-function openPinDialog(renderResult: ReturnType<typeof renderPinButton>) {
+async function openPinDialog(renderResult: ReturnType<typeof renderPinButton>) {
   fireEvent.click(renderResult.getByRole("button", { name: "Pin case" }));
-  return getPinDialog(renderResult);
+  return renderResult.findByRole("dialog");
 }
 
 function getPinDialog(renderResult: ReturnType<typeof renderPinButton>) {
@@ -76,7 +76,7 @@ function submitPinDialog(renderResult: ReturnType<typeof renderPinButton>) {
 
 function submitPinDialogWithShortcut(
   renderResult: ReturnType<typeof renderPinButton>,
-  modifier: KeyboardModifier,
+  modifier: SubmitKeyModifier,
 ) {
   fireEvent.keyDown(getPinReasonField(renderResult), {
     key: "Enter",
@@ -89,12 +89,12 @@ describe("PinButton", () => {
     usePinnedCasesMock.mockReset();
   });
 
-  it("prompts for an optional reason before pinning", () => {
+  it("prompts for an optional reason before pinning", async () => {
     // ARRANGE
     const { pin, renderResult } = setupPinButton();
 
     // ACT
-    const dialog = openPinDialog(renderResult);
+    const dialog = await openPinDialog(renderResult);
     expect(
       within(dialog).getByText(
         "Add an optional reason for pinning this case. This stays attached to the pin only and does not create a note.",
@@ -107,12 +107,12 @@ describe("PinButton", () => {
     expect(pin).toHaveBeenCalledWith("case-1", "Pending morning triage");
   });
 
-  it("pin dialog can be submitted without a reason", () => {
+  it("pin dialog can be submitted without a reason", async () => {
     // ARRANGE
     const { pin, renderResult } = setupPinButton({}, { caseName: undefined });
 
     // ACT
-    openPinDialog(renderResult);
+    await openPinDialog(renderResult);
     submitPinDialog(renderResult);
 
     // ASSERT
@@ -124,19 +124,37 @@ describe("PinButton", () => {
     [{ ctrlKey: false, metaKey: true }, "Mac shortcut works too"],
   ] as const)(
     "submits the pin dialog with keyboard shortcut %j",
-    (modifier, reason) => {
+    async (modifier, reason) => {
       // ARRANGE
       const { pin, renderResult } = setupPinButton();
 
       // ACT
-      openPinDialog(renderResult);
+      const dialog = await openPinDialog(renderResult);
       fillPinReason(renderResult, reason);
+      expect(await axe(dialog)).toHaveNoViolations();
       submitPinDialogWithShortcut(renderResult, modifier);
 
       // ASSERT
+      expect(pin).toHaveBeenCalledTimes(1);
       expect(pin).toHaveBeenCalledWith("case-1", reason);
     },
   );
+
+  it("does not submit the pin dialog for Enter without modifiers", async () => {
+    // ARRANGE
+    const { pin, renderResult } = setupPinButton();
+
+    // ACT
+    await openPinDialog(renderResult);
+    fillPinReason(renderResult, "Do not submit");
+    submitPinDialogWithShortcut(renderResult, {
+      ctrlKey: false,
+      metaKey: false,
+    });
+
+    // ASSERT
+    expect(pin).not.toHaveBeenCalled();
+  });
 
   it("does not show the dialog when unpinning an already pinned case", () => {
     // ARRANGE

--- a/components/common/PinButton.tsx
+++ b/components/common/PinButton.tsx
@@ -188,11 +188,14 @@ export function PinButton({
                 placeholder="Add an optional reason for pinning this case"
                 className="min-h-24"
                 maxLength={MAX_PIN_REASON_LENGTH}
-                aria-describedby={`pin-reason-description-${caseId}`}
+                aria-describedby={`pin-reason-description-${caseId} pin-reason-shortcut-${caseId}`}
                 onKeyDown={handleSubmitShortcut}
                 autoFocus
               />
-              <p className="text-xs text-muted-foreground text-right">
+              <p
+                id={`pin-reason-shortcut-${caseId}`}
+                className="text-xs text-muted-foreground text-right"
+              >
                 Press <Kbd>Ctrl</Kbd>/<Kbd>⌘</Kbd>+<Kbd>Enter</Kbd> to pin
               </p>
             </div>


### PR DESCRIPTION
This pull request enhances the `PinButton` component by adding keyboard shortcut support for submitting the pin dialog using Ctrl+Enter or Cmd+Enter, improving accessibility and user experience. It also updates the UI to inform users about the new shortcut and adds corresponding tests to ensure the feature works as expected.

**Keyboard shortcut support for pinning:**
- Added a `useSubmitShortcut` hook to enable submitting the pin dialog via Ctrl+Enter (Windows/Linux) or Cmd+Enter (Mac) in the `PinButton` component. The textarea now listens for these key combinations to trigger the pin action. [[1]](diffhunk://#diff-6a4d4f8e30f73b80d673d788e39181955f880f60b7a74c3dbe5d9b93498276caR21) [[2]](diffhunk://#diff-6a4d4f8e30f73b80d673d788e39181955f880f60b7a74c3dbe5d9b93498276caR93-R102) [[3]](diffhunk://#diff-6a4d4f8e30f73b80d673d788e39181955f880f60b7a74c3dbe5d9b93498276caR192-R197)
- Updated the UI to display a hint below the pin reason textarea, informing users about the new keyboard shortcut.

**Testing improvements:**
- Added tests to verify that the pin dialog submits correctly when using Ctrl+Enter or Cmd+Enter, ensuring cross-platform support for the shortcut.

**Code simplification:**
- Refactored the pin submission logic into a `handleSubmit` function to avoid duplication and improve readability. [[1]](diffhunk://#diff-6a4d4f8e30f73b80d673d788e39181955f880f60b7a74c3dbe5d9b93498276caR93-R102) [[2]](diffhunk://#diff-6a4d4f8e30f73b80d673d788e39181955f880f60b7a74c3dbe5d9b93498276caL167-R179)

**UI component updates:**
- Imported and used the `Kbd` component to visually represent keyboard keys in the UI hint. [[1]](diffhunk://#diff-6a4d4f8e30f73b80d673d788e39181955f880f60b7a74c3dbe5d9b93498276caR12) [[2]](diffhunk://#diff-6a4d4f8e30f73b80d673d788e39181955f880f60b7a74c3dbe5d9b93498276caR192-R197)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now submit the pin dialog using Ctrl/⌘ + Enter keyboard shortcut, bypassing the need to click the button
  * Added on-screen hint displaying the available keyboard shortcut in the pin dialog

* **Tests**
  * Added test cases verifying pin dialog submission via keyboard shortcuts on both Windows/Linux (Ctrl) and Mac (⌘) platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->