### PR TITLE
docs: clarify persisted and runtime case model surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ The app currently persists a canonical normalized v2.1 format with flat collecti
 ```ts
 interface PersistedNormalizedFileDataV21 {
   version: "2.1";
-  people: StoredPerson[];
-  cases: PersistedCase[];
+  people: StoredPerson[];        // Note: uses StoredPerson, not PersistedPerson
+  cases: PersistedCase[];         // Note: uses PersistedCase, not StoredCase
   financials: StoredFinancialItem[];
   notes: StoredNote[];
   alerts: AlertRecord[];
@@ -97,6 +97,8 @@ interface PersistedNormalizedFileDataV21 {
   templates?: Template[];
 }
 ```
+
+> **Naming convention note:** The mixed use of `StoredPerson` and `PersistedCase` reflects the evolution of the type system. `StoredPerson` distinguishes the persisted shape from the hydrated `Person` (which includes circular references), while `PersistedCase` distinguishes the on-disk format from `StoredCase` (the hydrated runtime case). This intentional distinction helps developers understand the different transformation layers.
 
 Persisted v2.1 data is hydrated and dehydrated through the storage helpers. Normal runtime reads now accept only canonical persisted v2.1 workspaces; legacy v2.0 and older formats must be upgraded first with the explicit migration tooling.
 

--- a/docs/development/v21-storage-design.md
+++ b/docs/development/v21-storage-design.md
@@ -447,7 +447,7 @@ Archived cases (`*.archive.json`, if any) use the same schema.  Options:
 | **Hydrate** | Resolve each `personId` in `CasePersonRef[]` → full `Person` objects at read time |
 | **Dehydrate** | Strip resolved `Person` objects back to `CasePersonRef[]` (ID refs only) at write time |
 
-> **Current repo naming note:** this design doc originally used `StoredCase` for the on-disk normalized shape. The current code distinguishes that persisted shape as `PersistedCase`, while `StoredCase` is the hydrated runtime case returned by services. Future documentation and cleanup work should follow the current code terminology.
+> **Current repo naming note:** The codebase uses `StoredPerson` for persisted people and `PersistedCase` for persisted cases, which appears inconsistent but reflects the evolution of the type system. `StoredPerson` was named to distinguish it from the hydrated `Person` type (which includes circular references like `familyMembers`), while `PersistedCase` was introduced later to distinguish the on-disk shape from `StoredCase` (the hydrated runtime case). Other entities use the `Stored*` prefix (`StoredFinancialItem`, `StoredNote`). This mixed naming convention is intentional and distinguishes between persisted formats and runtime hydration layers.
 >
 > **`CaseRecord` note:** `CaseRecord` is not the canonical persisted v2.1 case model. In today's code, `CaseRecord.financials` and `CaseRecord.notes` are stale nested-case debt, while `CaseRecord.personId` and `CaseRecord.spouseId` remain active compatibility scaffolding until the remaining type cleanup lands. New persisted work should target normalized storage types; new runtime/UI work should target the hydrated case composite/view model.
 


### PR DESCRIPTION
This pull request updates documentation to clarify the distinctions between persisted, runtime, and compatibility case models in the app, aligning terminology with the current codebase and providing guidance for contributors on how to handle type surfaces during ongoing cleanup.

**Documentation updates and clarification:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R89): Updated the description of the persisted data model to use `PersistedNormalizedFileDataV21` and clarified the difference between persisted, hydrated runtime, and compatibility/transitional case model layers. Added guidance on the current and future use of `CaseRecord` and related types. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R103-R118)
* [`docs/development/v21-storage-design.md`](diffhunk://#diff-4ae960084df11bd02fb1d0b751ec276f6aeb5a1846bc39e253a87f94041d8f11L444-R453): Revised the terminology table to match current code usage, clearly distinguishing between `PersistedCase` (persisted model), `StoredCase` (hydrated runtime model), and `CaseRecord` (compatibility layer). Added notes on naming and the transitional state of certain fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified storage model with a three-layer framing: canonical persisted format, hydrated runtime view, and a compatibility/transitional surface
  * Added guidance on naming conventions for persisted vs runtime entities
  * Marked legacy case-records as non-canonical and specified which fields are compatibility-only
  * Minor formatting/cleanup in docs files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->