### PR TITLE
refactor: remove application migration bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ interface PersistedNormalizedFileDataV21 {
 
 > **Naming convention note:** The mixed use of `StoredPerson` and `PersistedCase` reflects the evolution of the type system. `StoredPerson` distinguishes the persisted shape from the hydrated `Person` (which includes circular references), while `PersistedCase` distinguishes the on-disk format from `StoredCase` (the hydrated runtime case). This intentional distinction helps developers understand the different transformation layers.
 
-Persisted v2.1 data is hydrated and dehydrated through the storage helpers. Normal runtime reads now accept only canonical persisted v2.1 workspaces; legacy v2.0 and older formats must be upgraded first with the explicit migration tooling.
+Persisted v2.1 data is hydrated and dehydrated through the storage helpers. Normal runtime reads now accept only canonical persisted v2.1 workspaces; legacy v2.0 and older formats must be upgraded first with the explicit migration tooling. Normal saves no longer synthesize canonical `applications[]` from case-embedded compatibility fields, so application ownership must be written explicitly by the owning create/edit flows.
 
 ### Case-model surfaces
 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ The main workspace file is:
 case-tracker-data.json
 ```
 
-The app currently persists a canonical normalized v2.1 format with flat collections and foreign keys:
+The app currently persists a canonical normalized v2.2 format with flat collections and foreign keys:
 
 ```ts
-interface PersistedNormalizedFileDataV21 {
-  version: "2.1";
+interface PersistedNormalizedFileDataV22 {
+  version: "2.2";
   people: StoredPerson[]; // Note: uses StoredPerson, not PersistedPerson
   cases: PersistedCase[]; // Note: uses PersistedCase, not StoredCase
+  applications: Application[];
   financials: StoredFinancialItem[];
   notes: StoredNote[];
   alerts: AlertRecord[];
@@ -100,7 +101,7 @@ interface PersistedNormalizedFileDataV21 {
 
 > **Naming convention note:** The mixed use of `StoredPerson` and `PersistedCase` reflects the evolution of the type system. `StoredPerson` distinguishes the persisted shape from the hydrated `Person` (which includes circular references), while `PersistedCase` distinguishes the on-disk format from `StoredCase` (the hydrated runtime case). This intentional distinction helps developers understand the different transformation layers.
 
-Persisted v2.1 data is hydrated and dehydrated through the storage helpers. Normal runtime reads now accept only canonical persisted v2.1 workspaces; legacy v2.0 and older formats must be upgraded first with the explicit migration tooling. Normal saves no longer synthesize canonical `applications[]` from case-embedded compatibility fields, so application ownership must be written explicitly by the owning create/edit flows.
+Persisted v2.2 data is hydrated and dehydrated through the storage helpers. Normal runtime reads now accept only canonical persisted v2.2 workspaces; legacy v2.1, v2.0, and older formats must be upgraded first with the explicit migration tooling. The generic read/dehydrate path no longer synthesizes canonical `applications[]` from case-embedded compatibility fields, so application ownership is expected to be written by the owning create/edit flows. During the v2.2 cutover, some service-level mutation paths still reconcile canonical applications alongside case updates.
 
 ### Case-model surfaces
 
@@ -108,11 +109,11 @@ When working on case-model changes, distinguish these three layers:
 
 1. **Canonical persisted model** — the file on disk stores normalized top-level collections and uses persisted types such as `PersistedCase` and `StoredPerson`. This is the source of truth for storage work.
 2. **Hydrated runtime/workspace model** — `FileStorageService` and `CaseService` resolve persisted references into runtime shapes such as `NormalizedFileData`, `StoredCase`, and the overlapping `CaseDisplay` surface used by current UI flows. This is the target for runtime UI and workspace behavior.
-3. **Compatibility/transitional type surface** — `CaseRecord` and related compatibility-oriented fields still exist to bridge older flows and current type debt. `CaseRecord` is **not** the canonical persisted v2.1 case model.
+3. **Compatibility/transitional type surface** — `CaseRecord` and related compatibility-oriented fields still exist to bridge older flows and current type debt. `CaseRecord` is **not** the canonical persisted v2.2 case model.
 
 Current `CaseRecord` guidance:
 
-- `financials` and `notes` are stale compatibility debt; canonical v2.1 stores them in top-level `financials[]` and `notes[]`, not inside each case.
+- `financials` and `notes` are stale compatibility debt; canonical v2.2 stores them in top-level `financials[]` and `notes[]`, not inside each case.
 - `personId` and `spouseId` are still active compatibility scaffolding in some flows, but authoritative person linkage is `PersistedCase.people[]`, with runtime hydration exposing `person` and `linkedPeople`.
 - Other case metadata on `CaseRecord` can still be active, so contributors should remove or reshape only the explicitly transitional fields rather than treating the whole type as dead.
 

--- a/__tests__/hooks/useConnectionFlow.test.ts
+++ b/__tests__/hooks/useConnectionFlow.test.ts
@@ -1,0 +1,113 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockToast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  loading: vi.fn(),
+  dismiss: vi.fn(),
+}));
+
+vi.mock("sonner", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("sonner")>();
+  return {
+    ...actual,
+    toast: mockToast,
+  };
+});
+
+import { useConnectionFlow } from "@/hooks/useConnectionFlow";
+import {
+  createMockFileStorageLifecycleSelectors,
+  createMockStoredCase,
+} from "@/src/test/testUtils";
+import type { DataManager } from "@/utils/DataManager";
+
+type UseConnectionFlowParams = Parameters<typeof useConnectionFlow>[0];
+
+describe("useConnectionFlow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a one-time upgrade toast before loading cases when the workspace is migrated", async () => {
+    // ARRANGE
+    const migrateWorkspaceToV22 = vi
+      .fn()
+      .mockResolvedValueOnce({
+        processedAt: "2026-04-09T00:00:00.000Z",
+        files: [],
+        summary: {
+          migrated: 1,
+          alreadyV21: 0,
+          failed: 0,
+          skipped: 0,
+        },
+      })
+      .mockResolvedValueOnce({
+        processedAt: "2026-04-09T00:00:01.000Z",
+        files: [],
+        summary: {
+          migrated: 0,
+          alreadyV21: 1,
+          failed: 0,
+          skipped: 0,
+        },
+      });
+    const loadCases = vi.fn().mockResolvedValue([createMockStoredCase({ id: "case-1" })]);
+    const setCases = vi.fn();
+    const setError = vi.fn();
+    const setHasLoadedData = vi.fn();
+    const mockDataManager = {
+      migrateWorkspaceToV22,
+    } as unknown as DataManager;
+    const initialProps: UseConnectionFlowParams = {
+      isSupported: true,
+      hasLoadedData: false,
+      connectionState: createMockFileStorageLifecycleSelectors(),
+      service: null,
+      fileStorageService: null,
+      dataManager: mockDataManager,
+      loadCases,
+      setCases,
+      setError,
+      setHasLoadedData,
+    };
+
+    const { result, rerender } = renderHook(
+      (props: UseConnectionFlowParams) => useConnectionFlow(props),
+      { initialProps },
+    );
+
+    // ACT
+    await act(async () => {
+      await result.current.handleConnectionComplete();
+    });
+
+    rerender({
+      ...initialProps,
+      hasLoadedData: true,
+    });
+
+    await act(async () => {
+      await result.current.handleConnectionComplete();
+    });
+
+    // ASSERT
+    expect(migrateWorkspaceToV22).toHaveBeenCalledTimes(2);
+    expect(mockToast.info).toHaveBeenCalledWith(
+      "Workspace upgraded to v2.2",
+      expect.objectContaining({ id: "workspace-upgraded" }),
+    );
+    expect(mockToast.info).toHaveBeenCalledOnce();
+    expect(migrateWorkspaceToV22.mock.invocationCallOrder[0]).toBeLessThan(
+      loadCases.mock.invocationCallOrder[0],
+    );
+    expect(loadCases).toHaveBeenCalledTimes(2);
+    expect(setCases).toHaveBeenCalledWith([expect.objectContaining({ id: "case-1" })]);
+    expect(setHasLoadedData).toHaveBeenCalledWith(true);
+    expect(setError).toHaveBeenCalledWith(null);
+  });
+});

--- a/__tests__/hooks/useConnectionFlow.test.ts
+++ b/__tests__/hooks/useConnectionFlow.test.ts
@@ -110,4 +110,48 @@ describe("useConnectionFlow", () => {
     expect(setHasLoadedData).toHaveBeenCalledWith(true);
     expect(setError).toHaveBeenCalledWith(null);
   });
+
+  it("reports workspace connection failures when migration fails before cases load", async () => {
+    // ARRANGE
+    const migrateWorkspaceToV22 = vi.fn().mockRejectedValue(new Error("migration exploded"));
+    const loadCases = vi.fn();
+    const setCases = vi.fn();
+    const setError = vi.fn();
+    const setHasLoadedData = vi.fn();
+    const mockDataManager = {
+      migrateWorkspaceToV22,
+    } as unknown as DataManager;
+
+    const { result } = renderHook(() =>
+      useConnectionFlow({
+        isSupported: true,
+        hasLoadedData: false,
+        connectionState: createMockFileStorageLifecycleSelectors(),
+        service: null,
+        fileStorageService: null,
+        dataManager: mockDataManager,
+        loadCases,
+        setCases,
+        setError,
+        setHasLoadedData,
+      }),
+    );
+
+    // ACT
+    await act(async () => {
+      await result.current.handleConnectionComplete();
+    });
+
+    // ASSERT
+    expect(loadCases).not.toHaveBeenCalled();
+    expect(setCases).not.toHaveBeenCalled();
+    expect(setHasLoadedData).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledWith(
+      "Failed to complete workspace connection: migration exploded",
+    );
+    expect(mockToast.error).toHaveBeenCalledWith(
+      "Failed to complete workspace connection: migration exploded",
+      expect.objectContaining({ id: "connection-error" }),
+    );
+  });
 });

--- a/__tests__/hooks/useIntakeWorkflow.test.ts
+++ b/__tests__/hooks/useIntakeWorkflow.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createBlankIntakeForm } from "@/domain/validation/intake.schema";
 import { INTAKE_STEPS } from "@/domain/cases/intake-steps";
 import { APPLICATION_STATUS } from "@/types/application";
-import type { CaseStatus } from "@/types/case";
 import {
   createMockApplication,
   createMockHouseholdMemberData,
@@ -55,9 +54,9 @@ const mockCategoryConfig = {
   caseStatuses: [
     { name: "Intake", colorSlot: "blue", countsAsCompleted: false },
     { name: "Pending", colorSlot: "amber", countsAsCompleted: false },
-    { name: "Approved", colorSlot: "green", countsAsCompleted: true },
-    { name: "Denied", colorSlot: "red", countsAsCompleted: true },
-    { name: "Withdrawn", colorSlot: "slate", countsAsCompleted: true },
+    { name: "Active", colorSlot: "green", countsAsCompleted: false },
+    { name: "Closed", colorSlot: "slate", countsAsCompleted: true },
+    { name: "Archived", colorSlot: "purple", countsAsCompleted: true },
   ],
   livingArrangements: ["Community"],
   groups: [],
@@ -296,12 +295,12 @@ describe("useIntakeWorkflow", () => {
       const terminalApplications = [
         createCaseApplication("case-edit-1", {
           id: "application-approved-1",
-          status: APPLICATION_STATUS.Approved,
+          status: APPLICATION_STATUS.Closed,
           applicationDate: "2026-01-01",
         }),
         createCaseApplication("case-edit-1", {
           id: "application-denied-1",
-          status: APPLICATION_STATUS.Denied,
+          status: APPLICATION_STATUS.Archived,
           applicationDate: "2026-02-01",
         }),
       ];
@@ -324,7 +323,7 @@ describe("useIntakeWorkflow", () => {
       const applications = [
         createCaseApplication("case-edit-1", {
           id: "application-approved-1",
-          status: APPLICATION_STATUS.Approved,
+          status: APPLICATION_STATUS.Closed,
           applicationDate: "2026-01-01",
         }),
         createCaseApplication("case-edit-1", {
@@ -399,7 +398,7 @@ describe("useIntakeWorkflow", () => {
       const refreshedApplications = [
         createCaseApplication("case-edit-1", {
           id: "application-approved-1",
-          status: APPLICATION_STATUS.Approved,
+          status: APPLICATION_STATUS.Closed,
           applicationDate: "2026-03-01",
         }),
       ];
@@ -446,7 +445,7 @@ describe("useIntakeWorkflow", () => {
       const terminalApplications = [
         createCaseApplication("case-terminal-1", {
           id: "application-approved-1",
-          status: APPLICATION_STATUS.Approved,
+          status: APPLICATION_STATUS.Closed,
           applicationDate: "2026-03-01",
         }),
       ];
@@ -1106,7 +1105,7 @@ describe("useIntakeWorkflow", () => {
           avsConsentDate: "2026-02-16",
           voterFormStatus: "requested",
           retroMonths: ["Jan", "Feb"],
-          status: "Approved" as CaseStatus,
+          status: "Closed",
         },
         person: createMockPerson({
           id: "person-edit-1",
@@ -1121,7 +1120,7 @@ describe("useIntakeWorkflow", () => {
         createMockApplication({
           id: "application-terminal-1",
           caseId: "case-edit-1",
-          status: APPLICATION_STATUS.Approved,
+          status: APPLICATION_STATUS.Closed,
           applicationDate: "2026-02-15",
         }),
       ]);
@@ -1168,7 +1167,7 @@ describe("useIntakeWorkflow", () => {
             avsConsentDate: "2026-02-16",
             voterFormStatus: "requested",
             retroMonths: ["Jan", "Feb"],
-            status: "Approved",
+            status: "Closed",
           }),
         }),
       );
@@ -1258,7 +1257,7 @@ describe("useIntakeWorkflow", () => {
           avsConsentDate: "2026-02-16",
           voterFormStatus: "requested",
           retroMonths: ["Jan", "Feb"],
-          status: "Approved" as CaseStatus,
+          status: "Closed",
         },
         person: createMockPerson({
           id: "person-edit-1",
@@ -1293,7 +1292,7 @@ describe("useIntakeWorkflow", () => {
           createMockApplication({
             id: "application-terminal-1",
             caseId: "case-edit-1",
-            status: APPLICATION_STATUS.Approved,
+            status: APPLICATION_STATUS.Closed,
             applicationDate: "2026-02-15",
           }),
         ])
@@ -1301,7 +1300,7 @@ describe("useIntakeWorkflow", () => {
           createMockApplication({
             id: "application-terminal-2",
             caseId: "case-edit-1",
-            status: APPLICATION_STATUS.Approved,
+            status: APPLICATION_STATUS.Closed,
             applicationDate: "2026-03-01",
           }),
         ]);

--- a/__tests__/hooks/useIntakeWorkflow.test.ts
+++ b/__tests__/hooks/useIntakeWorkflow.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/hooks/useDataSync", () => ({
 const mockDataManager = {
   createCompleteCase: vi.fn(),
   updateCompleteCase: vi.fn(),
+  updateApplication: vi.fn(),
   getAllPeople: vi.fn(),
   getApplicationsForCase: vi.fn(),
   getCaseById: vi.fn(),
@@ -149,6 +150,7 @@ describe("useIntakeWorkflow", () => {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
+      mockDataManager.updateApplication.mockResolvedValue(createMockApplication());
     // Keep people reads pending by default so tests that only care about
     // immediate mount state do not trigger avoidable async act warnings.
     mockDataManager.getAllPeople.mockImplementation(() => createPendingPromise());
@@ -1222,6 +1224,16 @@ describe("useIntakeWorkflow", () => {
         "case-edit-1",
         expect.objectContaining({
           caseRecord: expect.objectContaining({
+            avsConsentDate: "",
+          }),
+        }),
+      );
+      expect(mockDataManager.updateApplication).toHaveBeenCalledWith(
+        "case-edit-1",
+        "application-pending-1",
+        expect.objectContaining({
+          applicationDate: "2026-02-15",
+          verification: expect.objectContaining({
             avsConsentDate: "",
           }),
         }),

--- a/__tests__/services/ApplicationService.test.ts
+++ b/__tests__/services/ApplicationService.test.ts
@@ -268,18 +268,18 @@ describe("ApplicationService", () => {
     // Act
     const result = await service.addStatusHistory("case-1", "application-1", {
       id: "history-2",
-      status: "Approved",
+      status: "Closed",
       effectiveDate: "2026-02-01",
       changedAt: "2026-02-01T00:00:00.000Z",
       source: "user",
     });
 
     // Assert
-    expect(result.status).toBe("Approved");
+    expect(result.status).toBe("Closed");
     expect(result.statusHistory).toHaveLength(initialApplication.statusHistory.length + 1);
     expect(result.statusHistory[1]).toMatchObject({
       id: "history-2",
-      status: "Approved",
+      status: "Closed",
     });
     expect(mockFileStorage.writeNormalizedData).toHaveBeenCalledTimes(1);
     const writtenData = mockFileStorage.writeNormalizedData.mock.calls[0][0];
@@ -290,7 +290,7 @@ describe("ApplicationService", () => {
       payload: {
         applicationId: "application-1",
         fromStatus: "Pending",
-        toStatus: "Approved",
+        toStatus: "Closed",
         effectiveDate: "2026-02-01",
         source: "user",
       },
@@ -305,7 +305,7 @@ describe("ApplicationService", () => {
     await expectConsistentTransactionTimestamp(async () => {
       await service.addStatusHistory("case-1", "application-1", {
         id: "history-2",
-        status: "Approved",
+        status: "Closed",
         effectiveDate: "2026-04-08",
         changedAt: TEST_TRANSACTION_TIMESTAMP,
         source: "user",
@@ -323,7 +323,7 @@ describe("ApplicationService", () => {
     await expect(
       service.addStatusHistory("case-1", "application-1", {
         id: "history-2",
-        status: "Approved",
+        status: "Closed",
         effectiveDate: "2026-02-01",
         changedAt: "2026-02-01T00:00:00.000Z",
         source: "user",

--- a/__tests__/services/CaseBulkOperationsService.bulk.test.ts
+++ b/__tests__/services/CaseBulkOperationsService.bulk.test.ts
@@ -17,7 +17,7 @@ const createMockFileStorage = (data: NormalizedFileData | null = null) => ({
 const createMockFileData = (
   overrides: Partial<NormalizedFileData> = {}
 ): NormalizedFileData => ({
-  version: '2.1',
+  version: '2.2',
   people: [],
   exported_at: new Date().toISOString(),
   total_cases: overrides.cases?.length ?? 0,

--- a/__tests__/services/CaseBulkOperationsService.test.ts
+++ b/__tests__/services/CaseBulkOperationsService.test.ts
@@ -90,15 +90,15 @@ describe('CaseBulkOperationsService', () => {
     return {
       ...defaultCategoryConfig,
       caseStatuses: [
-        { name: 'Approved', colorSlot: 'green', countsAsCompleted: true },
-        { name: 'Denied', colorSlot: 'red', countsAsCompleted: true },
+        { name: 'Closed', colorSlot: 'slate', countsAsCompleted: true },
+        { name: 'Archived', colorSlot: 'purple', countsAsCompleted: true },
         { name: 'Pending', colorSlot: 'amber', countsAsCompleted: false },
       ],
     };
   }
 
   function createCanonicalStatusSyncData(primaryPersonId = 'person-1') {
-    const baseCase = createMockCase('case-1', 'Approved' as CaseStatus);
+    const baseCase = createMockCase('case-1', 'Closed');
     const data = createEmptyNormalizedData({
       categoryConfig: createCompletedStatusConfig(),
       people: [
@@ -130,7 +130,7 @@ describe('CaseBulkOperationsService', () => {
           applicantPersonId: primaryPersonId,
           applicationDate: '2026-01-01',
           applicationType: 'Renewal',
-          status: 'Approved',
+          status: 'Closed',
           hasWaiver: true,
           retroRequestedAt: '2025-12-01',
           retroMonths: ['2025-12'],
@@ -146,7 +146,7 @@ describe('CaseBulkOperationsService', () => {
           statusHistory: [
             {
               id: 'history-1',
-              status: 'Approved',
+              status: 'Closed',
               effectiveDate: '2026-01-01',
               changedAt: '2026-01-01T00:00:00.000Z',
               source: 'migration',
@@ -415,7 +415,7 @@ describe('CaseBulkOperationsService', () => {
       expect(writtenData.applications?.[0].statusHistory).toEqual([
         {
           id: 'history-1',
-          status: 'Approved',
+          status: 'Closed',
           effectiveDate: '2026-01-01',
           changedAt: '2026-01-01T00:00:00.000Z',
           source: 'migration',
@@ -640,7 +640,7 @@ describe('CaseBulkOperationsService', () => {
 
       expect(mockFileStorage.writeNormalizedData).toHaveBeenCalledWith(
         expect.objectContaining({
-          version: '2.1',
+          version: '2.2',
           people: [],
           cases: [],
           financials: [],

--- a/__tests__/services/CaseService.test.ts
+++ b/__tests__/services/CaseService.test.ts
@@ -291,6 +291,13 @@ describe("CaseService hydration seam", () => {
         },
       ]);
       expect(writtenData.cases[0].caseRecord.personId).toBe(writtenData.people[0].id);
+      expect(writtenData.applications).toHaveLength(1);
+      expect(writtenData.applications[0]).toMatchObject({
+        caseId: writtenData.cases[0].id,
+        applicantPersonId: writtenData.people[0].id,
+        applicationDate: newCaseRecordData.applicationDate,
+        applicationType: newCaseRecordData.applicationType ?? "",
+      });
       expect(result.person).toMatchObject({
         id: writtenData.people[0].id,
         firstName: "Taylor",
@@ -564,6 +571,106 @@ describe("CaseService hydration seam", () => {
   });
 
   describe("updateCaseStatus", () => {
+    it("does not rewrite canonical application fields during a plain case update", async () => {
+      // ARRANGE
+      const primaryPerson = createMockPerson({
+        id: "person-case-1",
+        firstName: "Primary",
+        lastName: "Person",
+        name: "Primary Person",
+      });
+      const canonicalApplication = createMockApplication({
+        id: "application-1",
+        caseId: "case-1",
+        applicantPersonId: "person-case-1",
+        applicationDate: "2026-02-15",
+        applicationType: "Renewal",
+        hasWaiver: true,
+        retroRequestedAt: "2026-01-01",
+        retroMonths: ["Jan", "Feb"],
+        verification: {
+          isAppValidated: true,
+          isAgedDisabledVerified: true,
+          isCitizenshipVerified: true,
+          isResidencyVerified: true,
+          avsConsentDate: "2026-02-16",
+          voterFormStatus: "requested",
+          isIntakeCompleted: true,
+        },
+      });
+      vi.mocked(mockFileService.readFile).mockResolvedValue(
+        createMockPersistedNormalizedFileData({
+          people: [primaryPerson],
+          cases: [
+            createCaseWithPrimaryApplicant(primaryPerson, {
+              caseRecord: {
+                mcn: "MCN-ORIGINAL",
+                applicationDate: "2026-02-15",
+                applicationType: "Renewal",
+                withWaiver: true,
+                retroRequested: "2026-01-01",
+                appValidated: true,
+                agedDisabledVerified: true,
+                citizenshipVerified: true,
+                residencyVerified: true,
+                avsConsentDate: "2026-02-16",
+                voterFormStatus: "requested",
+                retroMonths: ["Jan", "Feb"],
+                status: "Pending",
+              },
+            }),
+          ],
+          applications: [canonicalApplication],
+        }),
+      );
+      vi.mocked(mockFileService.writeFile).mockResolvedValue(true);
+
+      // ACT
+      await caseService.updateCompleteCase("case-1", {
+        person: createMockNewPersonData({
+          firstName: "Primary",
+          lastName: "Person",
+        }),
+        caseRecord: createMockNewCaseRecordData({
+          personId: "person-case-1",
+          mcn: "MCN-UPDATED",
+          applicationDate: "2026-09-09",
+          applicationType: "Stale Disabled Edit",
+          withWaiver: false,
+          retroRequested: "2026-09-01",
+          appValidated: false,
+          agedDisabledVerified: false,
+          citizenshipVerified: false,
+          residencyVerified: false,
+          avsConsentDate: "2026-09-10",
+          voterFormStatus: "declined",
+          retroMonths: ["Sep"],
+          status: "Pending",
+        }),
+      });
+
+      // ASSERT
+      const writtenData = vi.mocked(mockFileService.writeFile).mock.calls[0][0];
+      expect(writtenData.applications).toHaveLength(1);
+      expect(writtenData.applications[0]).toMatchObject({
+        id: "application-1",
+        applicationDate: "2026-02-15",
+        applicationType: "Renewal",
+        hasWaiver: true,
+        retroRequestedAt: "2026-01-01",
+        retroMonths: ["Jan", "Feb"],
+        verification: {
+          isAppValidated: true,
+          isAgedDisabledVerified: true,
+          isCitizenshipVerified: true,
+          isResidencyVerified: true,
+          avsConsentDate: "2026-02-16",
+          voterFormStatus: "requested",
+          isIntakeCompleted: true,
+        },
+      });
+    });
+
     it("synchronizes canonical application status/history while preserving historical applicant linkage", async () => {
       // ARRANGE
       const primaryPerson = createMockPerson({ id: "person-case-1", name: "Primary Person" });

--- a/__tests__/services/CaseService.test.ts
+++ b/__tests__/services/CaseService.test.ts
@@ -726,7 +726,7 @@ describe("CaseService hydration seam", () => {
         applicationDate: "2026-01-01",
         applicationType: "Renewal",
         createdAt: "2026-01-01T00:00:00.000Z",
-        status: "Approved",
+        status: "Closed",
         hasWaiver: true,
         retroRequestedAt: "2025-12-01",
         retroMonths: ["2025-12"],
@@ -742,7 +742,7 @@ describe("CaseService hydration seam", () => {
         statusHistory: [
           {
             id: "history-1",
-            status: "Approved",
+            status: "Closed",
             effectiveDate: "2026-01-01",
             changedAt: "2026-01-01T00:00:00.000Z",
             source: "migration",
@@ -755,11 +755,11 @@ describe("CaseService hydration seam", () => {
         applicantPersonId: "person-case-1",
         applicationDate: "2026-03-01",
         createdAt: "2026-03-01T00:00:00.000Z",
-        status: "Denied",
+        status: "Archived",
         statusHistory: [
           {
             id: "history-2",
-            status: "Denied",
+            status: "Archived",
             effectiveDate: "2026-03-01",
             changedAt: "2026-03-01T00:00:00.000Z",
             source: "migration",
@@ -770,17 +770,17 @@ describe("CaseService hydration seam", () => {
         createMockPersistedNormalizedFileData({
           categoryConfig: mergeCategoryConfig({
             caseStatuses: [
-              { name: "Approved", colorSlot: "green", countsAsCompleted: true },
-              { name: "Denied", colorSlot: "red", countsAsCompleted: true },
+              { name: "Closed", colorSlot: "slate", countsAsCompleted: true },
+              { name: "Archived", colorSlot: "purple", countsAsCompleted: true },
               { name: "Pending", colorSlot: "amber", countsAsCompleted: false },
             ],
           }),
           people: [primaryPerson],
           cases: [
             createCaseWithPrimaryApplicant(primaryPerson, {
-              status: "Approved" as CaseStatus,
+              status: "Closed",
               caseRecord: {
-                status: "Approved" as CaseStatus,
+                status: "Closed",
                 applicationDate: "1999-04-01",
                 applicationType: "Stale Legacy Type",
                 withWaiver: false,

--- a/__tests__/services/CategoryConfigService.test.ts
+++ b/__tests__/services/CategoryConfigService.test.ts
@@ -22,7 +22,7 @@ describe("CategoryConfigService", () => {
     
     mockFileStorage = {
       readFileData: vi.fn().mockResolvedValue({
-        version: "2.1",
+        version: "2.2",
         people: [],
         cases: [],
         financials: [],

--- a/__tests__/services/FileStorageService.test.ts
+++ b/__tests__/services/FileStorageService.test.ts
@@ -192,7 +192,7 @@ describe("FileStorageService v2.1", () => {
     expect(mockFileService.writeFile).not.toHaveBeenCalled();
   });
 
-  it("migrates legacy case-embedded application fields into canonical applications on read", async () => {
+  it("hydrates explicit migrated applications on read without rewriting the workspace", async () => {
     // ARRANGE
     const migratedPersistedData = migrateV20ToV21({
       ...createMockNormalizedFileDataV20(),
@@ -234,12 +234,7 @@ describe("FileStorageService v2.1", () => {
       hasWaiver: true,
       retroRequestedAt: "2026-02-01",
     });
-    expect(mockFileService.broadcastDataUpdate).toHaveBeenCalledWith(result);
-    expect(mockFileService.writeFile).toHaveBeenCalledTimes(1);
-    const writtenData = mockFileService.writeFile.mock.calls[0][0];
-    expect(writtenData.applications).toHaveLength(1);
-    expect(writtenData.cases[0].caseRecord).not.toHaveProperty("applicationDate");
-    expect(writtenData.cases[0].caseRecord).not.toHaveProperty("withWaiver");
+    expect(mockFileService.writeFile).not.toHaveBeenCalled();
   });
 
   it("rejects invalid persisted v2.1 payloads that fail hydration", async () => {
@@ -306,7 +301,7 @@ describe("FileStorageService v2.1", () => {
       id: "person-1",
       name: "Migrated Workspace",
     });
-    expect(mockFileService.writeFile).toHaveBeenCalledTimes(1);
+    expect(mockFileService.writeFile).not.toHaveBeenCalled();
   });
 
   it("hydrates dehydrated writes from the canonical terminal application order instead of the first match", async () => {
@@ -408,11 +403,7 @@ describe("FileStorageService v2.1", () => {
     expect(writtenData.cases[0].people).toEqual([
       { personId: "person-1", role: "applicant", isPrimary: true },
     ]);
-    expect(writtenData.applications).toHaveLength(1);
-    expect(writtenData.applications[0]).toMatchObject({
-      caseId: "case-1",
-      applicantPersonId: "person-1",
-    });
+    expect(writtenData.applications).toEqual([]);
     expect(writtenData.cases[0].caseRecord).not.toHaveProperty("applicationDate");
     expect(writtenData.cases[0].caseRecord).not.toHaveProperty("applicationType");
     expect(writtenData.cases[0].caseRecord).not.toHaveProperty("withWaiver");

--- a/__tests__/services/FileStorageService.test.ts
+++ b/__tests__/services/FileStorageService.test.ts
@@ -11,13 +11,17 @@ import {
   createMockNormalizedFileData,
   createMockNormalizedFileDataV20,
   createMockPersistedNormalizedFileData,
+  createMockPersistedNormalizedFileDataV21,
   createMockPerson,
   createMockStoredCase,
 } from "@/src/test/testUtils";
 import type AutosaveFileService from "@/utils/AutosaveFileService";
-import { migrateV20ToV21 } from "@/utils/storageV21Migration";
+import {
+  migrateV20ToV21,
+  type PersistedNormalizedFileDataV21,
+} from "@/utils/storageV21Migration";
 
-describe("FileStorageService v2.1", () => {
+describe("FileStorageService v2.2", () => {
   let fileStorage: FileStorageService;
   let mockFileService: {
     readFile: ReturnType<typeof vi.fn>;
@@ -54,19 +58,6 @@ describe("FileStorageService v2.1", () => {
       },
       ...caseOverrides,
     });
-  }
-
-  function expectHydratedSingleApplicantCase(
-    result: Awaited<ReturnType<FileStorageService["readFileData"]>>,
-    expectedPerson: { id: string; name: string },
-  ) {
-    expect(result?.version).toBe("2.1");
-    expect(result?.people).toHaveLength(1);
-    expect(result?.people[0].id).toBe(expectedPerson.id);
-    expect(result?.cases[0].person.name).toBe(expectedPerson.name);
-    expect(result?.cases[0].people).toEqual([
-      { personId: expectedPerson.id, role: "applicant", isPrimary: true },
-    ]);
   }
 
   function expectCanonicalCaseApplicationFields(
@@ -124,9 +115,18 @@ describe("FileStorageService v2.1", () => {
     // ACT & ASSERT
     const readPromise = fileStorage.readFileData();
     await expect(readPromise).rejects.toThrow(LegacyFormatError);
-    await expect(readPromise).rejects.toThrow(
-      "Use the persisted v2.1 migration tool in Settings → Diagnostics",
+    expect(mockFileService.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects persisted v2.1 workspaces during normal runtime reads until they are upgraded", async () => {
+    // ARRANGE
+    mockFileService.readFile.mockResolvedValue(
+      migrateV20ToV21(createMockNormalizedFileDataV20()),
     );
+
+    // ACT & ASSERT
+    const readPromise = fileStorage.readFileData();
+    await expect(readPromise).rejects.toThrow(LegacyFormatError);
     expect(mockFileService.writeFile).not.toHaveBeenCalled();
   });
 
@@ -142,7 +142,7 @@ describe("FileStorageService v2.1", () => {
     expect(mockFileService.writeFile).not.toHaveBeenCalled();
   });
 
-  it("hydrates persisted v2.1 data on read without rewriting it", async () => {
+  it("returns persisted v2.1 data unchanged for explicit migration utilities", async () => {
     // ARRANGE
     const hydratedCase = createSingleApplicantStoredCase(
       {
@@ -161,38 +161,31 @@ describe("FileStorageService v2.1", () => {
         updatedAt: "2026-01-02T00:00:00.000Z",
       },
     );
-    mockFileService.readFile.mockResolvedValue(createMockPersistedNormalizedFileData({
+    const persistedData = createMockPersistedNormalizedFileDataV21({
       people: [hydratedCase.person],
       cases: [hydratedCase],
       exported_at: "2026-03-01T00:00:00.000Z",
       total_cases: 1,
-    }));
+    });
+    mockFileService.readFile.mockResolvedValue(persistedData);
 
     // ACT
-    const result = await fileStorage.readFileData();
+    const result = await fileStorage.readRawFileData() as PersistedNormalizedFileDataV21 | null;
 
     // ASSERT
-    expectHydratedSingleApplicantCase(result, {
-      id: "person-1",
+    expect(result?.version).toBe("2.1");
+    expect(result?.people).toHaveLength(1);
+    expect(result?.people[0]).toMatchObject({ id: "person-1", name: "Hydrated Person" });
+    expect(result?.cases).toHaveLength(1);
+    expect(result?.cases[0]).toMatchObject({
       name: "Hydrated Person",
+      people: [{ personId: "person-1", role: "applicant", isPrimary: true }],
+      caseRecord: expect.objectContaining({ personId: "person-1" }),
     });
-    expect(result?.cases[0].linkedPeople).toEqual([
-      {
-        person: expect.objectContaining({
-          id: "person-1",
-          name: "Hydrated Person",
-        }),
-        ref: {
-          personId: "person-1",
-          role: "applicant",
-          isPrimary: true,
-        },
-      },
-    ]);
     expect(mockFileService.writeFile).not.toHaveBeenCalled();
   });
 
-  it("hydrates explicit migrated applications on read without rewriting the workspace", async () => {
+  it("returns migrated applications unchanged for explicit migration utilities", async () => {
     // ARRANGE
     const migratedPersistedData = migrateV20ToV21({
       ...createMockNormalizedFileDataV20(),
@@ -224,7 +217,7 @@ describe("FileStorageService v2.1", () => {
     mockFileService.readFile.mockResolvedValue(migratedPersistedData);
 
     // ACT
-    const result = await fileStorage.readFileData();
+    const result = await fileStorage.readRawFileData() as PersistedNormalizedFileDataV21 | null;
 
     // ASSERT
     expect(result?.applications).toHaveLength(1);
@@ -237,9 +230,9 @@ describe("FileStorageService v2.1", () => {
     expect(mockFileService.writeFile).not.toHaveBeenCalled();
   });
 
-  it("rejects invalid persisted v2.1 payloads that fail hydration", async () => {
+  it("returns invalid persisted v2.1 payloads unchanged for explicit migration validation", async () => {
     // ARRANGE
-    const invalidPersistedData = createMockPersistedNormalizedFileData({
+    const invalidPersistedData = createMockPersistedNormalizedFileDataV21({
       cases: [
         createMockStoredCase({
           id: "case-invalid",
@@ -259,16 +252,18 @@ describe("FileStorageService v2.1", () => {
       people: [],
     });
 
-    // ACT & ASSERT
-    const readPromise = fileStorage.readFileData();
-    await expect(readPromise).rejects.toThrow(LegacyFormatError);
-    await expect(readPromise).rejects.toThrow("invalid v2.1 workspace");
-    await expect(readPromise).rejects.toThrow(
-      "Use the persisted v2.1 migration tool in Settings → Diagnostics",
-    );
+    // ACT
+    const result = await fileStorage.readRawFileData() as PersistedNormalizedFileDataV21 | null;
+
+    // ASSERT
+    expect(result).toMatchObject({
+      version: "2.1",
+      people: [],
+      cases: [expect.objectContaining({ id: "case-invalid" })],
+    });
   });
 
-  it("hydrates v2.1 workspaces that were migrated from v2.0", async () => {
+  it("returns v2.1 workspaces migrated from v2.0 unchanged for explicit migration utilities", async () => {
     // ARRANGE
     const migratedPersistedData = migrateV20ToV21({
       ...createMockNormalizedFileDataV20(),
@@ -294,12 +289,16 @@ describe("FileStorageService v2.1", () => {
     mockFileService.readFile.mockResolvedValue(migratedPersistedData);
 
     // ACT
-    const result = await fileStorage.readFileData();
+    const result = await fileStorage.readRawFileData() as PersistedNormalizedFileDataV21 | null;
 
     // ASSERT
-    expectHydratedSingleApplicantCase(result, {
-      id: "person-1",
+    expect(result?.version).toBe("2.1");
+    expect(result?.people).toHaveLength(1);
+    expect(result?.people[0]).toMatchObject({ id: "person-1", name: "Migrated Workspace" });
+    expect(result?.cases).toHaveLength(1);
+    expect(result?.cases[0]).toMatchObject({
       name: "Migrated Workspace",
+      caseRecord: expect.objectContaining({ personId: "person-1" }),
     });
     expect(mockFileService.writeFile).not.toHaveBeenCalled();
   });
@@ -309,8 +308,8 @@ describe("FileStorageService v2.1", () => {
     const categoryConfig: CategoryConfig = {
       ...createMockNormalizedFileData().categoryConfig,
       caseStatuses: [
-        { name: "Approved", colorSlot: "green", countsAsCompleted: true },
-        { name: "Denied", colorSlot: "red", countsAsCompleted: true },
+        { name: "Closed", colorSlot: "slate", countsAsCompleted: true },
+        { name: "Archived", colorSlot: "purple", countsAsCompleted: true },
         { name: "Pending", colorSlot: "amber", countsAsCompleted: false },
       ],
     };
@@ -336,7 +335,7 @@ describe("FileStorageService v2.1", () => {
           applicantPersonId: "person-1",
           applicationDate: "2026-03-01",
           createdAt: "2026-03-01T00:00:00.000Z",
-          status: "Denied",
+          status: "Archived",
           applicationType: "Newer Terminal",
         }),
         createMockApplication({
@@ -345,7 +344,7 @@ describe("FileStorageService v2.1", () => {
           applicantPersonId: "person-1",
           applicationDate: "2026-01-01",
           createdAt: "2026-01-01T00:00:00.000Z",
-          status: "Approved",
+          status: "Closed",
           applicationType: "Older Terminal",
         }),
       ],
@@ -393,7 +392,7 @@ describe("FileStorageService v2.1", () => {
     // ASSERT
     const writtenData = mockFileService.writeFile.mock.calls[0][0];
 
-    expect(writtenData.version).toBe("2.1");
+    expect(writtenData.version).toBe("2.2");
     expect(writtenData.people).toHaveLength(1);
     expect(writtenData.people[0].familyMemberIds).toEqual([
       "44444444-4444-4444-8444-444444444444",
@@ -412,7 +411,7 @@ describe("FileStorageService v2.1", () => {
     expect(writtenRuntimeData.cases[0].person.id).toBe("person-1");
     expect(mockFileService.broadcastDataUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        version: "2.1",
+        version: "2.2",
         people: [
           expect.objectContaining({
             id: "person-1",

--- a/__tests__/services/FinancialsService.test.ts
+++ b/__tests__/services/FinancialsService.test.ts
@@ -75,7 +75,7 @@ describe('FinancialsService', () => {
   });
 
   const createBaseMockData = (): NormalizedFileData => ({
-    version: '2.1',
+    version: '2.2',
     people: [],
     cases: [createMockCase('case-1')],
     financials: [],

--- a/__tests__/services/PersonService.test.ts
+++ b/__tests__/services/PersonService.test.ts
@@ -36,7 +36,7 @@ describe("PersonService", () => {
     });
 
     return {
-      version: "2.1",
+      version: "2.2",
       people: [caseItem.person],
       cases: [caseItem],
       financials: [],

--- a/__tests__/utils/DataManager.test.ts
+++ b/__tests__/utils/DataManager.test.ts
@@ -1,20 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DataManager } from "@/utils/DataManager";
 import type AutosaveFileService from "@/utils/AutosaveFileService";
-import { FileStorageService, type NormalizedFileData } from "@/utils/services/FileStorageService";
+import { FileStorageService } from "@/utils/services/FileStorageService";
 import type { AlertRecord, StoredCase } from "@/types/case";
 import {
   createMockCaseDisplay,
   createMockNormalizedFileData,
   createMockNormalizedFileDataV20,
+  createMockPersistedNormalizedFileDataV21,
   createMockPerson,
   createMockStoredCase,
 } from "@/src/test/testUtils";
 import {
-  buildPersistedArchiveDataV21,
+  buildPersistedArchiveDataV22,
   MAIN_WORKSPACE_FILE_NAME,
 } from "@/utils/workspaceV21Migration";
-import { dehydrateNormalizedData } from "@/utils/storageV21Migration";
+import {
+  dehydrateNormalizedData,
+  type RuntimeNormalizedFileDataV22,
+} from "@/utils/storageV21Migration";
 
 // ============================================================================
 // Mocks
@@ -98,7 +102,7 @@ function createHydratedStoredCase(id: string, personId: string, name: string): {
   };
 }
 
-function createLinkedRuntimeWriteData(): NormalizedFileData {
+function createLinkedRuntimeWriteData(): RuntimeNormalizedFileDataV22 {
   const primaryPerson = createMockPerson({ id: "person-1" });
   const linkedPerson = createMockPerson({ id: "person-2" });
   const runtimeCase = createMockCaseDisplay({
@@ -391,7 +395,7 @@ describe("DataManager", () => {
       });
       expect(mockFileStorageService.writeNormalizedData).toHaveBeenCalledTimes(1);
       const writtenData = (mockFileStorageService.writeNormalizedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(writtenData.version).toBe("2.1");
+      expect(writtenData.version).toBe("2.2");
       expect(writtenData.people).toHaveLength(1);
       expect(writtenData.cases[0].person.id).toBe("person-1");
     });
@@ -429,7 +433,7 @@ describe("DataManager", () => {
       expect(mockFileService.listDataFiles).not.toHaveBeenCalled();
     });
 
-    it("migrates supported archive files to persisted v2.1", async () => {
+    it("migrates supported archive files to persisted v2.2", async () => {
       // ARRANGE
       const archiveData = createArchiveRuntimeData();
       (mockFileStorageService.readRawFileData as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -465,7 +469,7 @@ describe("DataManager", () => {
         "archived-cases-2026.json",
       );
       expect((mockFileService.writeNamedFile as ReturnType<typeof vi.fn>).mock.calls[0][1]).toMatchObject({
-        version: "2.1",
+        version: "2.2",
         archiveType: "cases",
         people: [expect.objectContaining({ id: "archive-person-1" })],
         cases: [
@@ -476,11 +480,11 @@ describe("DataManager", () => {
       });
     });
 
-    it("is idempotent when rerun against already-persisted v2.1 files", async () => {
+    it("is idempotent when rerun against already-current v2.2 files", async () => {
       // ARRANGE
       const runtimeData = createLinkedRuntimeWriteData();
       const persistedWorkspace = dehydrateNormalizedData(runtimeData);
-      const persistedArchive = buildPersistedArchiveDataV21(createArchiveRuntimeData());
+      const persistedArchive = buildPersistedArchiveDataV22(createArchiveRuntimeData());
 
       (mockFileStorageService.readRawFileData as ReturnType<typeof vi.fn>).mockResolvedValue(persistedWorkspace);
       (mockFileStorageService.writeNormalizedData as ReturnType<typeof vi.fn>).mockClear();
@@ -501,14 +505,14 @@ describe("DataManager", () => {
         skipped: 0,
       });
       expect(result.files.map((file) => file.disposition)).toEqual([
-        "already-v2.1",
-        "already-v2.1",
+        "already-current",
+        "already-current",
       ]);
       expect(mockFileStorageService.writeNormalizedData).not.toHaveBeenCalled();
       expect(mockFileService.writeNamedFile).not.toHaveBeenCalled();
     });
 
-    it("writes canonical archive metadata for normalized v2.1 archive files missing archive fields", async () => {
+    it("writes canonical archive metadata for normalized v2.2 archive files missing archive fields", async () => {
       // ARRANGE
       const nonCanonicalArchive = dehydrateNormalizedData({
         ...createLinkedRuntimeWriteData(),
@@ -534,11 +538,11 @@ describe("DataManager", () => {
       expect(result.files[1]).toMatchObject({
         fileName: "archived-cases-2026.json",
         disposition: "migrated",
-        sourceVersion: "2.1",
+        sourceVersion: "2.2",
       });
       expect(mockFileService.writeNamedFile).toHaveBeenCalledTimes(1);
       expect((mockFileService.writeNamedFile as ReturnType<typeof vi.fn>).mock.calls[0][1]).toMatchObject({
-        version: "2.1",
+        version: "2.2",
         archiveType: "cases",
         archiveYear: 2026,
         archivedAt: "2026-03-01T00:00:00.000Z",
@@ -588,6 +592,96 @@ describe("DataManager", () => {
         'Case case-invalid caseRecord.personId "person-missing" does not resolve to a person record.',
       ]);
       expect(mockFileStorageService.writeNormalizedData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("migrateWorkspaceToV22", () => {
+    it("preserves bridge-era application data during the persisted v2.1 to v2.2 cutover and writes once", async () => {
+      // ARRANGE
+      type DataManagerCutoverSubject = DataManager & {
+        migrateWorkspaceToV22(): Promise<{
+          summary: {
+            migrated: number;
+            alreadyV21: number;
+            failed: number;
+            skipped: number;
+          };
+        }>;
+      };
+      const person = createMockPerson({
+        id: "person-bridge-1",
+        firstName: "Mira",
+        lastName: "Grant",
+        name: "Mira Grant",
+      });
+      const runtimeCase = createMockStoredCase({
+        id: "case-bridge-1",
+        person,
+        people: [{ personId: person.id, role: "applicant", isPrimary: true }],
+        caseRecord: {
+          ...createMockStoredCase().caseRecord,
+          personId: person.id,
+          status: "Active",
+        },
+      });
+      const persistedV21Base = createMockPersistedNormalizedFileDataV21({
+        people: [person],
+        cases: [runtimeCase],
+        applications: [],
+      });
+      const persistedCase = persistedV21Base.cases[0];
+      const bridgeEraPersistedV21 = {
+        ...persistedV21Base,
+        applications: [],
+        cases: [
+          {
+            ...persistedCase,
+            caseRecord: {
+              ...persistedCase.caseRecord,
+              applicationDate: "2026-02-14",
+              applicationType: "Renewal",
+              withWaiver: true,
+              retroRequested: "2026-02-01",
+              appValidated: true,
+              retroMonths: ["2026-01"],
+              agedDisabledVerified: false,
+              citizenshipVerified: true,
+              residencyVerified: true,
+              avsConsentDate: "2026-02-04",
+              voterFormStatus: "requested",
+              intakeCompleted: false,
+            },
+          },
+        ],
+      };
+
+      (mockFileStorageService.readRawFileData as ReturnType<typeof vi.fn>).mockResolvedValue(
+        bridgeEraPersistedV21,
+      );
+      (mockFileService.listDataFiles as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      const subject = dataManager as DataManagerCutoverSubject;
+
+      // ACT
+      const result = await subject.migrateWorkspaceToV22();
+
+      // ASSERT
+      expect(result.summary).toEqual({
+        migrated: 1,
+        alreadyV21: 0,
+        failed: 0,
+        skipped: 0,
+      });
+      expect(mockFileStorageService.writeNormalizedData).toHaveBeenCalledTimes(1);
+      const writtenData = (mockFileStorageService.writeNormalizedData as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(writtenData).toMatchObject({ version: "2.2" });
+      expect(writtenData.applications).toHaveLength(1);
+      expect(writtenData.applications[0]).toMatchObject({
+        caseId: "case-bridge-1",
+        applicantPersonId: "person-bridge-1",
+        applicationType: "Renewal",
+        retroRequestedAt: "2026-02-01",
+      });
     });
   });
 

--- a/__tests__/utils/activityReport.test.ts
+++ b/__tests__/utils/activityReport.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/utils/activityReport";
 import type {
   CaseActivityEntry,
+  CaseApplicationStatusChangeActivity,
   DailyActivityReport,
   DailyCaseActivityBreakdown,
 } from "../../types/activityLog";
@@ -193,7 +194,7 @@ describe("generateDailyActivityReport", () => {
       },
     };
 
-    const applicationStatusChangeEntry: CaseActivityEntry = {
+    const applicationStatusChangeEntry: CaseApplicationStatusChangeActivity = {
       id: "application-status-change-1",
       timestamp: "2025-10-05T11:00:00.000Z",
       caseId: "case-2",
@@ -203,7 +204,7 @@ describe("generateDailyActivityReport", () => {
       payload: {
         applicationId: "app-2",
         fromStatus: "Pending",
-        toStatus: "Approved",
+        toStatus: "Closed",
         effectiveDate: "2025-10-05",
         source: "user",
       },

--- a/__tests__/utils/legacyMigration.test.ts
+++ b/__tests__/utils/legacyMigration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { migrateLegacyData } from "@/utils/legacyMigration";
+import { getFormatDescription, migrateLegacyData } from "@/utils/legacyMigration";
 import {
   createMockPerson,
   createMockPersistedNormalizedFileDataV21,
@@ -9,6 +9,11 @@ import {
 import { mergeCategoryConfig } from "@/types/categoryConfig";
 
 describe("legacyMigration", () => {
+  it("describes v2.2 payloads as the current normalized format", () => {
+    expect(getFormatDescription("v2.2")).toBe("v2.2 Normalized Format (current)");
+    expect(getFormatDescription("v2.1")).toBe("v2.1 Normalized Format (upgrade required)");
+  });
+
   it("hydrates persisted v2.1 data before returning it without success-path errors", () => {
     const runtimeCase = createMockStoredCase({
       id: "case-1",

--- a/__tests__/utils/legacyMigration.test.ts
+++ b/__tests__/utils/legacyMigration.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { migrateLegacyData } from "@/utils/legacyMigration";
-import { createMockPerson, createMockStoredCase } from "@/src/test/testUtils";
-import { dehydrateNormalizedData } from "@/utils/storageV21Migration";
+import {
+  createMockPerson,
+  createMockPersistedNormalizedFileDataV21,
+  createMockStoredCase,
+} from "@/src/test/testUtils";
 import { mergeCategoryConfig } from "@/types/categoryConfig";
 
 describe("legacyMigration", () => {
@@ -18,8 +21,7 @@ describe("legacyMigration", () => {
       people: [{ personId: "person-1", role: "applicant", isPrimary: true }],
     });
 
-    const persistedV21 = dehydrateNormalizedData({
-      version: "2.1",
+    const persistedV21 = createMockPersistedNormalizedFileDataV21({
       people: [runtimeCase.person],
       cases: [runtimeCase],
       financials: [],
@@ -35,7 +37,7 @@ describe("legacyMigration", () => {
 
     expect(result.success).toBe(true);
     expect(result.errors).toEqual([]);
-    expect(result.data?.version).toBe("2.1");
+    expect(result.data?.version).toBe("2.2");
     expect(result.data?.cases[0].person.name).toBe("Hydrated Person");
     expect(result.data?.cases[0].people).toEqual([
       { personId: "person-1", role: "applicant", isPrimary: true },

--- a/__tests__/utils/storageV21Migration.test.ts
+++ b/__tests__/utils/storageV21Migration.test.ts
@@ -19,6 +19,7 @@ import {
   isPersistedNormalizedFileDataV20,
   isPersistedNormalizedFileDataV21,
   migrateV20ToV21,
+  migrateV21ToV22,
   normalizePersistedApplication,
   persistedCasesContainLegacyApplicationFields,
   syncRuntimeApplications,
@@ -1005,6 +1006,80 @@ describe("storageV21Migration", () => {
     });
 
     expect(migrated.people[0].updatedAt).toBe(explicitUpdatedAt);
+  });
+
+  it("normalizes missing intakeCompleted when creating migrated applications from v2.0 cases", () => {
+    // ARRANGE
+    const runtimeCase = createMockStoredCase({
+      id: "case-1",
+      person: createMockPerson({ id: "person-1" }),
+      people: [{ personId: "person-1", role: "applicant", isPrimary: true }],
+    });
+    delete (runtimeCase.caseRecord as { intakeCompleted?: boolean }).intakeCompleted;
+
+    // ACT
+    const migrated = migrateV20ToV21({
+      version: "2.0",
+      cases: [runtimeCase],
+      financials: [],
+      notes: [],
+      alerts: [],
+      exported_at: "2026-03-01T00:00:00.000Z",
+      total_cases: 1,
+      categoryConfig: mergeCategoryConfig(),
+      activityLog: [],
+    });
+
+    // ASSERT
+    const [migratedApplication] = migrated.applications ?? [];
+
+    expect(migrated.applications).toHaveLength(1);
+    expect(migratedApplication?.verification.isIntakeCompleted).toBe(true);
+  });
+
+  it("uses exported_at as the deterministic timestamp when upgrading v2.1 to v2.2", () => {
+    // ARRANGE
+    const exportedAt = "2026-03-01T00:00:00.000Z";
+    const runtimeCase = createMockStoredCase({
+      id: "case-1",
+      status: "Pending",
+      person: createMockPerson({ id: "person-1" }),
+      people: [{ personId: "person-1", role: "applicant", isPrimary: true }],
+      caseRecord: {
+        ...createMockStoredCase().caseRecord,
+        personId: "person-1",
+        status: "Pending",
+        applicationDate: "2026-02-15",
+      },
+    });
+    const persistedV21 = createMockPersistedNormalizedFileDataV21({
+      people: [runtimeCase.person],
+      cases: [runtimeCase],
+      financials: [],
+      notes: [],
+      alerts: [],
+      exported_at: exportedAt,
+      total_cases: 1,
+      categoryConfig: mergeCategoryConfig(),
+      activityLog: [],
+    });
+
+    // ACT
+    const migrated = migrateV21ToV22(persistedV21);
+
+    // ASSERT
+    const [migratedApplication] = migrated.applications ?? [];
+
+    expect(migrated.applications).toHaveLength(1);
+    expect(migratedApplication).toMatchObject({
+      createdAt: exportedAt,
+      updatedAt: exportedAt,
+      statusHistory: [
+        expect.objectContaining({
+          changedAt: exportedAt,
+        }),
+      ],
+    });
   });
 
   it("round-trips runtime v2.1 data through dehydration and hydration without losing linked people", () => {

--- a/__tests__/utils/storageV21Migration.test.ts
+++ b/__tests__/utils/storageV21Migration.test.ts
@@ -307,7 +307,7 @@ describe("storageV21Migration", () => {
     expect(dehydrated.applications?.[0].verification).not.toHaveProperty("legacyFlag");
   });
 
-  it("writes intakeCompleted as true when dehydrating historical runtime cases without the field", () => {
+  it("does not synthesize applications when dehydrating historical runtime cases without the field", () => {
     // ARRANGE
     const runtimeCase = createMockStoredCase();
     delete (runtimeCase.caseRecord as { intakeCompleted?: boolean }).intakeCompleted;
@@ -328,12 +328,10 @@ describe("storageV21Migration", () => {
     const dehydrated = dehydrateNormalizedData(runtimeData);
 
     // ASSERT
-    expect(dehydrated.applications).toBeDefined();
-    expect(dehydrated.applications).toHaveLength(1);
-    expect(dehydrated.applications![0].verification.isIntakeCompleted).toBe(true);
+    expect(dehydrated.applications).toEqual([]);
   });
 
-  it("stores applications canonically and strips application-owned case fields during dehydration", () => {
+  it("does not synthesize applications during dehydration when runtime data has none", () => {
     // ARRANGE
     const runtimeCase = createMockStoredCase({
       id: "case-1",
@@ -364,13 +362,7 @@ describe("storageV21Migration", () => {
     });
 
     // ASSERT
-    expect(dehydrated.applications).toHaveLength(1);
-    expect(dehydrated.applications?.[0]).toMatchObject({
-      caseId: "case-1",
-      applicationType: "Renewal",
-      hasWaiver: true,
-      retroRequestedAt: "2026-02-01",
-    });
+    expect(dehydrated.applications).toEqual([]);
     expect(dehydrated.cases[0].caseRecord).not.toHaveProperty("applicationDate");
     expect(dehydrated.cases[0].caseRecord).not.toHaveProperty("retroRequested");
     expect(dehydrated.cases[0].caseRecord).not.toHaveProperty("withWaiver");

--- a/__tests__/utils/storageV21Migration.test.ts
+++ b/__tests__/utils/storageV21Migration.test.ts
@@ -6,6 +6,7 @@ import {
   createMockNormalizedFileData,
   createMockPerson,
   createMockPersistedNormalizedFileData,
+  createMockPersistedNormalizedFileDataV21,
   createMockStoredCase,
 } from "@/src/test/testUtils";
 import type { ApplicationStatus } from "@/types/application";
@@ -14,6 +15,7 @@ import type { NormalizedFileDataV20, PersistedNormalizedFileDataV21 } from "@/ut
 import {
   dehydrateNormalizedData,
   hydrateNormalizedData,
+  hydratePersistedNormalizedDataV21ForUpgrade,
   isPersistedNormalizedFileDataV20,
   isPersistedNormalizedFileDataV21,
   migrateV20ToV21,
@@ -192,7 +194,7 @@ describe("storageV21Migration", () => {
       activityLog: [],
     };
 
-    const hydrated = hydrateNormalizedData(persistedData);
+    const hydrated = hydratePersistedNormalizedDataV21ForUpgrade(persistedData);
 
     expect(hydrated.cases[0].person.id).toBe("person-1");
     expect(hydrated.cases[0].linkedPeople).toHaveLength(2);
@@ -203,8 +205,7 @@ describe("storageV21Migration", () => {
     // ARRANGE
     const runtimeCase = createMockStoredCase();
     delete (runtimeCase.caseRecord as { intakeCompleted?: boolean }).intakeCompleted;
-    const persistedData = dehydrateNormalizedData({
-      version: "2.1",
+    const persistedData = createMockPersistedNormalizedFileDataV21({
       people: [createMockPerson()],
       cases: [runtimeCase],
       financials: [],
@@ -218,7 +219,7 @@ describe("storageV21Migration", () => {
     delete (persistedData.cases[0].caseRecord as { intakeCompleted?: boolean }).intakeCompleted;
 
     // ACT
-    const hydrated = hydrateNormalizedData(persistedData);
+    const hydrated = hydratePersistedNormalizedDataV21ForUpgrade(persistedData);
 
     // ASSERT
     expect(hydrated.cases[0].caseRecord.intakeCompleted).toBe(true);
@@ -312,7 +313,7 @@ describe("storageV21Migration", () => {
     const runtimeCase = createMockStoredCase();
     delete (runtimeCase.caseRecord as { intakeCompleted?: boolean }).intakeCompleted;
     const runtimeData = {
-      version: "2.1" as const,
+      version: "2.2" as const,
       people: [createMockPerson()],
       cases: [runtimeCase],
       financials: [],
@@ -348,7 +349,7 @@ describe("storageV21Migration", () => {
 
     // ACT
     const dehydrated = dehydrateNormalizedData({
-      version: "2.1",
+      version: "2.2",
       people: [createMockPerson({ id: "person-1" })],
       cases: [runtimeCase],
       applications: [],
@@ -391,7 +392,7 @@ describe("storageV21Migration", () => {
           id: "application-approved",
           caseId: "case-1",
           applicationDate: "2026-01-01",
-          status: "Approved",
+          status: "Closed",
           applicationType: "Closed Application",
           updatedAt: "2026-04-03T00:00:00.000Z",
         }),
@@ -416,7 +417,7 @@ describe("storageV21Migration", () => {
         caseStatuses: [
           { name: "Pending Review", colorSlot: "amber", countsAsCompleted: false },
           { name: "Escalated", colorSlot: "orange", countsAsCompleted: false },
-          { name: "Approved", colorSlot: "green", countsAsCompleted: true },
+          { name: "Closed", colorSlot: "slate", countsAsCompleted: true },
         ],
       }),
     });
@@ -456,7 +457,7 @@ describe("storageV21Migration", () => {
           id: "application-terminal-oldest",
           caseId: "case-1",
           applicationDate: "2026-01-01",
-          status: "Approved",
+          status: "Closed",
           applicationType: "Renewal",
           hasWaiver: true,
           retroRequestedAt: "2025-12-01",
@@ -466,7 +467,7 @@ describe("storageV21Migration", () => {
           id: "application-terminal-newer",
           caseId: "case-1",
           applicationDate: "2026-03-01",
-          status: "Denied",
+          status: "Archived",
           applicationType: "Change Report",
           hasWaiver: false,
           retroRequestedAt: null,
@@ -475,8 +476,8 @@ describe("storageV21Migration", () => {
       ],
       categoryConfig: mergeCategoryConfig({
         caseStatuses: [
-          { name: "Approved", colorSlot: "green", countsAsCompleted: true },
-          { name: "Denied", colorSlot: "red", countsAsCompleted: true },
+          { name: "Closed", colorSlot: "slate", countsAsCompleted: true },
+          { name: "Archived", colorSlot: "purple", countsAsCompleted: true },
           { name: "Pending Review", colorSlot: "amber", countsAsCompleted: false },
         ],
       }),
@@ -490,13 +491,13 @@ describe("storageV21Migration", () => {
     expect(hydrated.cases[0].caseRecord.applicationType).toBe("Renewal");
     expect(hydrated.cases[0].caseRecord.withWaiver).toBe(true);
     expect(hydrated.cases[0].caseRecord.retroRequested).toBe("2025-12-01");
-    expect(hydrated.cases[0].caseRecord.status).toBe("Approved");
+    expect(hydrated.cases[0].caseRecord.status).toBe("Closed");
   });
 
   it("hydrates runtime case fields back from canonical applications", () => {
     // ARRANGE
     const persistedData = dehydrateNormalizedData({
-      version: "2.1",
+      version: "2.2",
       people: [createMockPerson({ id: "person-1" })],
       cases: [
         createMockStoredCase({
@@ -678,11 +679,11 @@ describe("storageV21Migration", () => {
       applicantPersonId: "person-1",
       applicationDate: "2026-03-01",
       createdAt: "2026-03-01T00:00:00.000Z",
-      status: "Denied",
+      status: "Archived",
       statusHistory: [
         {
           id: "history-2",
-          status: "Denied",
+          status: "Archived",
           effectiveDate: "2026-03-01",
           changedAt: "2026-03-01T00:00:00.000Z",
           source: "migration",
@@ -692,8 +693,8 @@ describe("storageV21Migration", () => {
     const runtimeData = createMockNormalizedFileData({
       categoryConfig: mergeCategoryConfig({
         caseStatuses: [
-          { name: "Approved", colorSlot: "green", countsAsCompleted: true },
-          { name: "Denied", colorSlot: "red", countsAsCompleted: true },
+          { name: "Closed", colorSlot: "slate", countsAsCompleted: true },
+          { name: "Archived", colorSlot: "purple", countsAsCompleted: true },
           { name: "Pending", colorSlot: "amber", countsAsCompleted: false },
         ],
       }),
@@ -720,11 +721,11 @@ describe("storageV21Migration", () => {
           applicantPersonId: "person-1",
           applicationDate: "2026-01-01",
           createdAt: "2026-01-01T00:00:00.000Z",
-          status: "Approved",
+          status: "Closed",
           statusHistory: [
             {
               id: "history-1",
-              status: "Approved",
+              status: "Closed",
               effectiveDate: "2026-01-01",
               changedAt: "2026-01-01T00:00:00.000Z",
               source: "migration",
@@ -765,11 +766,11 @@ describe("storageV21Migration", () => {
       applicantPersonId: "person-1",
       applicationDate: "2026-03-01",
       createdAt: "2026-03-01T00:00:00.000Z",
-      status: "Denied",
+      status: "Archived",
       statusHistory: [
         {
           id: "history-2",
-          status: "Denied",
+          status: "Archived",
           effectiveDate: "2026-03-01",
           changedAt: "2026-03-01T00:00:00.000Z",
           source: "migration",
@@ -779,8 +780,8 @@ describe("storageV21Migration", () => {
     const runtimeData = createMockNormalizedFileData({
       categoryConfig: mergeCategoryConfig({
         caseStatuses: [
-          { name: "Approved", colorSlot: "green", countsAsCompleted: true },
-          { name: "Denied", colorSlot: "red", countsAsCompleted: true },
+          { name: "Closed", colorSlot: "slate", countsAsCompleted: true },
+          { name: "Archived", colorSlot: "purple", countsAsCompleted: true },
           { name: "Pending", colorSlot: "amber", countsAsCompleted: false },
         ],
       }),
@@ -818,7 +819,7 @@ describe("storageV21Migration", () => {
           applicationDate: "2026-01-01",
           applicationType: "Renewal",
           createdAt: "2026-01-01T00:00:00.000Z",
-          status: "Approved",
+          status: "Closed",
           hasWaiver: true,
           retroRequestedAt: "2025-12-01",
           retroMonths: ["2025-12"],
@@ -834,7 +835,7 @@ describe("storageV21Migration", () => {
           statusHistory: [
             {
               id: "history-1",
-              status: "Approved",
+              status: "Closed",
               effectiveDate: "2026-01-01",
               changedAt: "2026-01-01T00:00:00.000Z",
               source: "migration",
@@ -878,7 +879,7 @@ describe("storageV21Migration", () => {
     expect(result.applications.find((application) => application.id === "application-1")?.statusHistory).toEqual([
       {
         id: "history-1",
-        status: "Approved",
+        status: "Closed",
         effectiveDate: "2026-01-01",
         changedAt: "2026-01-01T00:00:00.000Z",
         source: "migration",
@@ -943,7 +944,7 @@ describe("storageV21Migration", () => {
   });
 
   it("dehydrates runtime familyMembers into familyMemberIds and legacyFamilyMemberNames", () => {
-    const runtimeData = hydrateNormalizedData(
+    const runtimeData = hydratePersistedNormalizedDataV21ForUpgrade(
       migrateV20ToV21({
         version: "2.0",
         cases: [
@@ -1027,7 +1028,7 @@ describe("storageV21Migration", () => {
       dateAdded: "2026-01-01T00:00:00.000Z",
     });
     const runtimeData = {
-      version: "2.1" as const,
+      version: "2.2" as const,
       people: [primaryPerson, secondaryPerson],
       cases: [
         createMockStoredCase({
@@ -1065,7 +1066,7 @@ describe("storageV21Migration", () => {
     const roundTripped = hydrateNormalizedData(dehydrateNormalizedData(runtimeData));
     const roundTrippedPrimaryPerson = roundTripped.people.find((person) => person.id === "person-1");
 
-    expect(roundTripped.version).toBe("2.1");
+    expect(roundTripped.version).toBe("2.2");
     expect(roundTripped.people).toHaveLength(2);
     expect(roundTrippedPrimaryPerson).toMatchObject({
       id: "person-1",

--- a/docs/development/ROADMAP_APR_2026.md
+++ b/docs/development/ROADMAP_APR_2026.md
@@ -193,7 +193,7 @@ Every feature must:
 
 ### Recommended Next Step
 
-Follow the canonical-intake ownership PR with the cleanup-and-surfacing slice: add application status-history rendering, decide how case-detail surfaces should present the selected canonical application data, and remove legacy migration-on-save or compatibility write paths once those screens are stable.
+Follow the canonical-intake ownership cleanup with the surfacing slice: add application status-history rendering and decide how case-detail surfaces should present the selected canonical application data now that legacy migration-on-save and read-time application rewrites have been removed from the normal runtime path.
 
 ---
 

--- a/docs/development/feature-catalogue.md
+++ b/docs/development/feature-catalogue.md
@@ -172,7 +172,7 @@ Maintained by the storage + autosave working group. Align telemetry follow-ups w
 
 Core case CRUD is highly mature. March 2026 completed the normalized people hydration milestone, and the audited April follow-through confirmed that existing-person reuse and relationship-driven household rendering are already live in the intake and case-details UI. The remaining narrow limitation is that intake edit does not yet support reassigning the primary applicant to a different existing person.
 
-The v2.2 application foundation now spans the domain, storage, service, hook, and intake UI layers. Intake create and intake edit now read and write application-owned fields through canonical `applications[]`, choosing the oldest non-terminal application by `applicationDate` with deterministic fallback across terminal-only sets. When edit mode has no non-terminal application to target, application-owned fields remain visible but locked so unsupported changes do not leak back into compatibility data.
+The v2.2 application foundation now spans the domain, storage, service, hook, and intake UI layers. Intake create and intake edit now read and write application-owned fields through canonical `applications[]`, choosing the oldest non-terminal application by `applicationDate` with deterministic fallback across terminal-only sets. Normal runtime saves no longer reconstruct canonical applications from case-embedded compatibility fields, and when edit mode has no non-terminal application to target, application-owned fields remain visible but locked so unsupported changes do not leak back into compatibility data.
 
 Case-detail and other non-intake surfaces still rely on hydrated compatibility fields rather than a dedicated application timeline UI. Status history now synchronizes canonically underneath those flows, but it is not yet surfaced as a first-class user-facing timeline.
 
@@ -207,6 +207,7 @@ Case-detail and other non-intake surfaces still rely on hydrated compatibility f
 - **Application Storage + Service Wiring**: Canonical `applications[]` support is now wired through storage migration helpers, `FileStorageService`, `DataManager`, and `ApplicationService` so the data layer can persist and manage application records independently of the case shell
 - **Canonical Intake Ownership**: Intake create/edit now persist application-owned fields through canonical application records instead of treating legacy case-embedded values as the source of truth
 - **Deterministic Application Selection**: Hydration and compatibility reads now choose the oldest non-terminal application by `applicationDate`, with deterministic fallback ordering for terminal-only sets
+- **Bridge-Free Runtime Writes**: New case creation and editable intake updates now write canonical applications explicitly, while ordinary runtime reads and case saves no longer rewrite or synthesize `applications[]`
 - **Protected Non-Intake Edits**: Live case-edit sections keep application-owned fields visible but disabled outside intake while downstream AVS-processing and review markers remain editable
 - **Import/Export**: Bulk operations with duplicate detection and progress indicators
 - **Autosave Integration**: Forms seamlessly integrate with AutosaveFileService for reliable persistence

--- a/docs/superpowers/plans/2026-04-09-canonical-workspace-cutover-implementation.md
+++ b/docs/superpowers/plans/2026-04-09-canonical-workspace-cutover-implementation.md
@@ -1,0 +1,485 @@
+# Canonical Workspace Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Safely land the bridge-free application ownership slice by auto-upgrading persisted `2.1` workspaces to canonical `2.2` on open and by reusing case-status values directly for application records in this PR.
+
+**Architecture:** Keep the migration upgrade explicit in the data layer, but invoke it automatically during the initial connection flow before normal runtime reads continue. Use the new `2.2` version boundary to prevent mixed `2.1` semantics, and collapse application status onto the existing case-status type for this slice so canonical application creation and status history stop depending on invalid cross-domain casts.
+
+**Tech Stack:** React 18, TypeScript, Vitest, Sonner toasts, FileStorageService/DataManager, local-first file storage.
+
+---
+
+## Task 1: Lock The Cutover And Status Behavior In Tests
+
+**Files:**
+
+- Modify: `/workspaces/CMSNext/__tests__/services/FileStorageService.test.ts`
+- Modify: `/workspaces/CMSNext/__tests__/utils/DataManager.test.ts`
+- Modify: `/workspaces/CMSNext/domain/applications/__tests__/migration.test.ts`
+- Create: `/workspaces/CMSNext/__tests__/hooks/useConnectionFlow.test.ts`
+
+- [ ] **Step 1: Write the failing storage test for strict `2.2` canonical reads**
+
+```ts
+it("rejects persisted v2.1 workspaces during normal runtime reads until they are upgraded", async () => {
+  vi.mocked(mockFileService.readFile).mockResolvedValue(
+    migrateV20ToV21(createMockNormalizedFileDataV20()),
+  );
+
+  await expect(fileStorageService.readFileData()).rejects.toThrow(
+    LegacyFormatError,
+  );
+});
+```
+
+- [ ] **Step 2: Run the focused FileStorageService test to verify it fails for the current code**
+
+Run: `npm run test:run -- __tests__/services/FileStorageService.test.ts`
+Expected: FAIL because the current runtime read path still accepts persisted `2.1`.
+
+- [ ] **Step 3: Write the failing DataManager migration test for auto-upgrading the primary workspace to `2.2`**
+
+```ts
+it("migrates a persisted v2.1 workspace to persisted v2.2", async () => {
+  const persistedV21 = migrateV20ToV21(createMockNormalizedFileDataV20());
+  mockFileStorageService.readRawFileData.mockResolvedValue(persistedV21);
+
+  const result = await dataManager.migrateWorkspaceToV22();
+
+  expect(result.summary.migrated).toBe(1);
+  expect(mockFileStorageService.writeNormalizedData).toHaveBeenCalledWith(
+    expect.objectContaining({ version: "2.2" }),
+  );
+});
+```
+
+- [ ] **Step 4: Write the failing hook test for the one-time upgrade notice on connect**
+
+```ts
+it("shows a one-time upgrade toast before loading cases when the workspace is migrated", async () => {
+  mockDataManager.migrateWorkspaceToV22.mockResolvedValue({
+    processedAt: "2026-04-09T00:00:00.000Z",
+    files: [],
+    summary: {
+      migrated: 1,
+      alreadyV21: 0,
+      failed: 0,
+      skipped: 0,
+    },
+  });
+
+  await result.current.handleConnectionComplete();
+
+  expect(toast.info).toHaveBeenCalledWith(
+    "Workspace upgraded to v2.2",
+    expect.any(Object),
+  );
+  expect(mockLoadCases).toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 5: Write the failing migration-domain test for shared case/application status ownership**
+
+```ts
+it("creates canonical applications using the case-status value directly", () => {
+  const application = createCanonicalApplication({
+    applicationId: "application-1",
+    initialHistoryId: "history-1",
+    caseId: "case-1",
+    applicantPersonId: "person-1",
+    createdAt: "2026-04-09T00:00:00.000Z",
+    caseRecord: {
+      applicationDate: "2026-04-09",
+      applicationType: "Renewal",
+      withWaiver: false,
+      retroRequested: "",
+      appValidated: false,
+      retroMonths: [],
+      agedDisabledVerified: false,
+      citizenshipVerified: false,
+      residencyVerified: false,
+      avsConsentDate: "",
+      voterFormStatus: "",
+      intakeCompleted: true,
+      status: "Active",
+    },
+  });
+
+  expect(application.status).toBe("Active");
+  expect(application.statusHistory[0]?.status).toBe("Active");
+});
+```
+
+- [ ] **Step 6: Run the focused red test set and verify it fails for the current implementation**
+
+Run: `npm run test:run -- __tests__/services/FileStorageService.test.ts __tests__/utils/DataManager.test.ts domain/applications/__tests__/migration.test.ts __tests__/hooks/useConnectionFlow.test.ts`
+Expected: FAIL because runtime `2.1` still reads successfully, migration still targets `2.1`, the hook does not emit an upgrade notice, and application status still depends on the old separate type.
+
+- [ ] **Step 7: Commit the red tests**
+
+```bash
+git add __tests__/services/FileStorageService.test.ts __tests__/utils/DataManager.test.ts domain/applications/__tests__/migration.test.ts __tests__/hooks/useConnectionFlow.test.ts
+git commit -m "test: lock workspace cutover behavior"
+```
+
+## Task 2: Introduce Canonical Persisted Version `2.2`
+
+**Files:**
+
+- Modify: `/workspaces/CMSNext/utils/storageV21Migration.ts`
+- Modify: `/workspaces/CMSNext/utils/workspaceV21Migration.ts`
+- Modify: `/workspaces/CMSNext/utils/legacyMigration.ts`
+
+- [ ] **Step 1: Add persisted/runtime `2.2` types and a dedicated `v2.1 -> v2.2` upgrade function**
+
+```ts
+export interface PersistedNormalizedFileDataV22 {
+  version: "2.2";
+  people: StoredPerson[];
+  cases: PersistedCase[];
+  applications?: Application[];
+  financials: StoredFinancialItem[];
+  notes: StoredNote[];
+  alerts: AlertRecord[];
+  exported_at: string;
+  total_cases: number;
+  categoryConfig: CategoryConfig;
+  activityLog: CaseActivityEntry[];
+  templates?: Template[];
+}
+
+export interface RuntimeNormalizedFileDataV22 {
+  version: "2.2";
+  people: Person[];
+  cases: StoredCase[];
+  applications?: Application[];
+  financials: StoredFinancialItem[];
+  notes: StoredNote[];
+  alerts: AlertRecord[];
+  exported_at: string;
+  total_cases: number;
+  categoryConfig: CategoryConfig;
+  activityLog: CaseActivityEntry[];
+  templates?: Template[];
+}
+
+export function migrateV21ToV22(
+  data: PersistedNormalizedFileDataV21,
+): PersistedNormalizedFileDataV22 {
+  const hydrated = hydrateNormalizedData(data);
+  const synced = syncRuntimeApplications(hydrated, {
+    preferRuntimeCaseFields: true,
+    syncMode: "full",
+  });
+
+  return {
+    ...dehydrateNormalizedData({
+      ...hydrated,
+      version: "2.2",
+      applications: synced.applications,
+    }),
+    version: "2.2",
+  };
+}
+```
+
+- [ ] **Step 2: Update the canonical runtime serializer and validators to target `2.2` only**
+
+```ts
+export function isPersistedNormalizedFileDataV22(
+  data: unknown,
+): data is PersistedNormalizedFileDataV22 {
+  const candidate = toNormalizedDataShapeCandidate(data);
+
+  return (
+    candidate?.version === "2.2" &&
+    Array.isArray(candidate.people) &&
+    hasNormalizedCollectionsAndMetadata(candidate)
+  );
+}
+
+export function dehydrateNormalizedData(
+  data: RuntimeNormalizedFileDataV22,
+): PersistedNormalizedFileDataV22 {
+  return {
+    version: "2.2",
+    people: persistedPeople,
+    cases: data.cases.map((caseItem) => dehydrateStoredCase(caseItem)),
+    applications: (data.applications ?? []).map(normalizePersistedApplication),
+    financials: data.financials.map((financial) => ({ ...financial })),
+    notes: data.notes.map((note) => ({ ...note })),
+    alerts: data.alerts.map((alert) => ({ ...alert })),
+    exported_at: data.exported_at,
+    total_cases: data.total_cases,
+    categoryConfig: data.categoryConfig,
+    activityLog: data.activityLog.map((entry) => ({ ...entry })),
+    templates: data.templates ? [...data.templates] : undefined,
+  };
+}
+```
+
+- [ ] **Step 3: Make the explicit migration utilities target `2.2` as the current canonical version**
+
+```ts
+export function validatePersistedV22Data(data: unknown): {
+  counts: WorkspaceMigrationCounts;
+  validationErrors: string[];
+} {
+  // same structural validation as today, but expect version "2.2"
+}
+
+export function buildPersistedArchiveDataV22(
+  archiveData: CaseArchiveData,
+): PersistedCaseArchiveDataV22 {
+  const persistedData = dehydrateNormalizedData(runtimeNormalizedData);
+  return {
+    ...persistedData,
+    version: "2.2",
+    archiveType: "cases",
+    archiveYear: archiveData.archiveYear,
+    archivedAt: archiveData.archivedAt,
+  };
+}
+```
+
+- [ ] **Step 4: Run the focused storage and migration tests to verify the new version boundary passes**
+
+Run: `npm run test:run -- __tests__/services/FileStorageService.test.ts __tests__/utils/DataManager.test.ts __tests__/utils/workspaceV21Migration.test.ts __tests__/utils/legacyMigration.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit the version-cutover layer**
+
+```bash
+git add utils/storageV21Migration.ts utils/workspaceV21Migration.ts utils/legacyMigration.ts __tests__/services/FileStorageService.test.ts __tests__/utils/DataManager.test.ts __tests__/utils/workspaceV21Migration.test.ts __tests__/utils/legacyMigration.test.ts
+git commit -m "refactor: cut over canonical workspace to v2.2"
+```
+
+## Task 3: Auto-Upgrade `2.1` Workspaces On Open
+
+**Files:**
+
+- Modify: `/workspaces/CMSNext/utils/DataManager.ts`
+- Modify: `/workspaces/CMSNext/hooks/useConnectionFlow.ts`
+- Modify: `/workspaces/CMSNext/components/diagnostics/WorkspaceMigrationPanel.tsx`
+- Modify: `/workspaces/CMSNext/__tests__/hooks/useConnectionFlow.test.ts`
+- Modify: `/workspaces/CMSNext/__tests__/components/diagnostics/WorkspaceMigrationPanel.test.tsx`
+
+- [ ] **Step 1: Replace the current `migrateWorkspaceToV21` entrypoint with `migrateWorkspaceToV22` and migrate `2.1` in the primary workspace path**
+
+```ts
+async migrateWorkspaceToV22(): Promise<WorkspaceMigrationReport> {
+  const files: WorkspaceMigrationFileReport[] = [];
+  files.push(await this.migratePrimaryWorkspaceFile());
+  return buildWorkspaceMigrationReport(files);
+}
+
+private async migratePrimaryWorkspaceFile(): Promise<WorkspaceMigrationFileReport> {
+  const rawData = await this.fileStorage.readRawFileData();
+
+  if (isPersistedNormalizedFileDataV22(rawData)) {
+    return {
+      fileName: MAIN_WORKSPACE_FILE_NAME,
+      fileKind: "workspace",
+      disposition: "already-current",
+      sourceVersion: rawData.version,
+      counts: summarizePersistedCounts(rawData),
+      validationErrors: [],
+      message: "Already persisted as v2.2.",
+    };
+  }
+
+  if (isPersistedNormalizedFileDataV21(rawData)) {
+    const migratedData = migrateV21ToV22(rawData);
+    await this.fileStorage.writeNormalizedData(hydrateNormalizedData(migratedData));
+    return {
+      fileName: MAIN_WORKSPACE_FILE_NAME,
+      fileKind: "workspace",
+      disposition: "migrated",
+      sourceVersion: rawData.version,
+      counts: summarizePersistedCounts(migratedData),
+      validationErrors: [],
+      message: "Migrated workspace file to persisted v2.2.",
+    };
+  }
+
+  if (isPersistedNormalizedFileDataV20(rawData)) {
+    const migratedData = migrateV21ToV22(migrateV20ToV21(rawData));
+    await this.fileStorage.writeNormalizedData(hydrateNormalizedData(migratedData));
+    return {
+      fileName: MAIN_WORKSPACE_FILE_NAME,
+      fileKind: "workspace",
+      disposition: "migrated",
+      sourceVersion: rawData.version,
+      counts: summarizePersistedCounts(migratedData),
+      validationErrors: [],
+      message: "Migrated workspace file to persisted v2.2.",
+    };
+  }
+
+  // keep the existing failure branch
+}
+```
+
+- [ ] **Step 2: Invoke the migration automatically during initial connection before `loadCases()` and show a one-time notice when a migration happened**
+
+```ts
+const migrationReport = dataManager
+  ? await dataManager.migrateWorkspaceToV22()
+  : null;
+
+if (migrationReport?.summary.migrated) {
+  toast.info("Workspace upgraded to v2.2", {
+    id: "workspace-upgraded",
+    description:
+      "Your saved data was upgraded to the new canonical workspace format.",
+  });
+}
+
+const loadedCases = await loadCases();
+```
+
+- [ ] **Step 3: Update the diagnostics panel to reflect the new current-version migration action**
+
+```tsx
+const migrationReport = await dataManager.migrateWorkspaceToV22();
+
+<Button onClick={handleMigrateWorkspace}>Upgrade Workspace To v2.2</Button>;
+```
+
+- [ ] **Step 4: Run the focused startup and diagnostics tests to verify auto-upgrade and notice behavior**
+
+Run: `npm run test:run -- __tests__/hooks/useConnectionFlow.test.ts __tests__/components/diagnostics/WorkspaceMigrationPanel.test.tsx __tests__/utils/DataManager.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit the automatic upgrade flow**
+
+```bash
+git add utils/DataManager.ts hooks/useConnectionFlow.ts components/diagnostics/WorkspaceMigrationPanel.tsx __tests__/hooks/useConnectionFlow.test.ts __tests__/components/diagnostics/WorkspaceMigrationPanel.test.tsx __tests__/utils/DataManager.test.ts
+git commit -m "feat: auto-upgrade v2.1 workspaces on open"
+```
+
+## Task 4: Reuse Case Status Directly For Applications In This Slice
+
+**Files:**
+
+- Modify: `/workspaces/CMSNext/types/application.ts`
+- Modify: `/workspaces/CMSNext/domain/applications/migration.ts`
+- Modify: `/workspaces/CMSNext/utils/storageV21Migration.ts`
+- Modify: `/workspaces/CMSNext/domain/applications/__tests__/migration.test.ts`
+- Modify: `/workspaces/CMSNext/__tests__/services/CaseService.test.ts`
+
+- [ ] **Step 1: Collapse the separate application-status type onto `CaseStatus` for this slice**
+
+```ts
+import type { CaseStatus, VoterFormStatus } from "@/types/case";
+
+export type ApplicationStatus = CaseStatus;
+
+export interface ApplicationStatusHistory {
+  id: string;
+  status: ApplicationStatus;
+  effectiveDate: string;
+  changedAt: string;
+  source: ApplicationStatusHistorySource;
+  notes?: string;
+}
+```
+
+- [ ] **Step 2: Remove the unsafe status cast from canonical application creation and status sync helpers**
+
+```ts
+export function createCanonicalApplication(
+  input: CreateCanonicalApplicationInput,
+): Application {
+  const applicationFields = pickApplicationOwnedCaseRecordFields(
+    input.caseRecord,
+  );
+  const status = input.caseRecord.status;
+
+  return {
+    id: input.applicationId,
+    caseId: input.caseId,
+    applicantPersonId: input.applicantPersonId,
+    applicationDate: applicationFields.applicationDate,
+    applicationType: applicationFields.applicationType,
+    status,
+    statusHistory: [
+      {
+        id: input.initialHistoryId,
+        status,
+        effectiveDate: applicationFields.applicationDate,
+        changedAt: input.createdAt,
+        source: "user",
+      },
+    ],
+    // remainder unchanged
+  };
+}
+```
+
+- [ ] **Step 3: Normalize the v2.0 migration path and runtime sync path around the shared status type**
+
+```ts
+function syncApplicationWithCase(
+  caseItem: StoredCase,
+  existingApplication: Application | null,
+  timestamp: string,
+  syncMode: RuntimeApplicationSyncMode = "full",
+): { application: Application; hasChanged: boolean } {
+  const sourceCaseRecord = createApplicationSourceCase(caseItem);
+  const nextStatus = sourceCaseRecord.status;
+
+  // existing logic, but no ApplicationStatus cast
+}
+```
+
+- [ ] **Step 4: Run the focused status tests to verify canonical creation and status history now share the case-status type**
+
+Run: `npm run test:run -- domain/applications/__tests__/migration.test.ts __tests__/services/CaseService.test.ts __tests__/utils/storageV21Migration.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit the transitional status alignment**
+
+```bash
+git add types/application.ts domain/applications/migration.ts utils/storageV21Migration.ts domain/applications/__tests__/migration.test.ts __tests__/services/CaseService.test.ts __tests__/utils/storageV21Migration.test.ts
+git commit -m "refactor: reuse case statuses for applications"
+```
+
+## Task 5: Update Documentation And Re-Validate The PR
+
+**Files:**
+
+- Modify: `/workspaces/CMSNext/README.md`
+- Modify: `/workspaces/CMSNext/docs/development/feature-catalogue.md`
+- Modify: `/workspaces/CMSNext/docs/development/ROADMAP_APR_2026.md`
+- Modify: `/workspaces/CMSNext/docs/superpowers/plans/2026-04-09-remove-application-migration-bridge.md`
+
+- [ ] **Step 1: Update documentation to say canonical bridge-free workspaces are persisted as `2.2` and that application status temporarily reuses case-status values**
+
+```md
+Persisted v2.2 data is the canonical bridge-free workspace format. Persisted v2.1 workspaces are upgraded automatically on open before normal runtime operations continue.
+
+For this slice, application records reuse the same status vocabulary as case records. A follow-up slice will move both record types onto the fully configurable shared status namespace.
+```
+
+- [ ] **Step 2: Refresh the older bridge-removal plan so it points at the approved cutover spec rather than the superseded versionless approach**
+
+```md
+This implementation now proceeds under `docs/superpowers/specs/2026-04-09-canonical-workspace-cutover-design.md`, which introduces the persisted `2.2` cutover and the transitional shared case-status approach for application records.
+```
+
+- [ ] **Step 3: Run full validation**
+
+Run: `npm run typecheck`
+Run: `npm run lint`
+Run: `npm run test:run`
+Run: `npm run build`
+Expected: PASS
+
+- [ ] **Step 4: Commit the docs and validation pass**
+
+```bash
+git add README.md docs/development/feature-catalogue.md docs/development/ROADMAP_APR_2026.md docs/superpowers/plans/2026-04-09-remove-application-migration-bridge.md
+git commit -m "docs: document canonical v2.2 cutover"
+```

--- a/docs/superpowers/plans/2026-04-09-remove-application-migration-bridge.md
+++ b/docs/superpowers/plans/2026-04-09-remove-application-migration-bridge.md
@@ -1,0 +1,294 @@
+# Remove Application Migration Bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove migration-on-save application syncing so canonical `applications[]` are written explicitly by owned flows instead of being reconstructed from case compatibility fields.
+
+**Architecture:** Keep canonical application reads and compatibility hydration for now, but delete the write-path bridge that syncs case fields into `applications[]`. Case creation keeps creating an initial canonical application explicitly, intake edit updates canonical applications directly, and case status changes use a narrow application-status sync instead of the broader migration helper.
+
+**Tech Stack:** React 18, TypeScript, Vitest, RTL, FileStorageService/DataManager services.
+
+---
+
+### Task 1: Lock The New Write Contract In Tests
+
+**Files:**
+
+- Modify: `__tests__/utils/storageV21Migration.test.ts`
+- Modify: `__tests__/hooks/useIntakeWorkflow.test.ts`
+- Modify: `__tests__/services/CaseService.test.ts`
+
+- [ ] **Step 1: Write failing storage tests for explicit application persistence**
+
+```ts
+it("does not synthesize applications during dehydration", () => {
+  const runtimeCase = createMockStoredCase({
+    id: "case-1",
+    person: createMockPerson({ id: "person-1" }),
+    people: [{ personId: "person-1", role: "applicant", isPrimary: true }],
+    caseRecord: {
+      ...createMockStoredCase().caseRecord,
+      applicationDate: "2026-03-01",
+      applicationType: "Renewal",
+      withWaiver: true,
+    },
+  });
+
+  const dehydrated = dehydrateNormalizedData({
+    version: "2.1",
+    people: [createMockPerson({ id: "person-1" })],
+    cases: [runtimeCase],
+    applications: [],
+    financials: [],
+    notes: [],
+    alerts: [],
+    exported_at: "2026-03-01T00:00:00.000Z",
+    total_cases: 1,
+    categoryConfig: mergeCategoryConfig(),
+    activityLog: [],
+  });
+
+  expect(dehydrated.applications).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run the focused storage test and confirm it fails for the old sync behavior**
+
+Run: `npm run test:run -- __tests__/utils/storageV21Migration.test.ts`
+Expected: FAIL because `dehydrateNormalizedData()` still creates an application automatically.
+
+- [ ] **Step 3: Write failing intake and case-service tests for explicit canonical application writes**
+
+```ts
+it("updates the canonical application directly during intake edit", async () => {
+  expect(mockDataManager.updateApplication).toHaveBeenCalledWith(
+    "case-1",
+    "application-1",
+    expect.objectContaining({
+      applicationDate: "2026-09-09",
+      applicationType: "Change Report",
+    }),
+  );
+});
+
+it("creates an initial canonical application when creating a case", async () => {
+  expect(result.applications).toHaveLength(1);
+  expect(result.applications?.[0]).toMatchObject({
+    caseId: createdCase.id,
+    applicationDate: "2026-02-15",
+  });
+});
+```
+
+- [ ] **Step 4: Run the focused test files and confirm they fail for the current bridge implementation**
+
+Run: `npm run test:run -- __tests__/hooks/useIntakeWorkflow.test.ts __tests__/services/CaseService.test.ts`
+Expected: FAIL because intake edit still relies on `updateCompleteCase()` only and case creation still depends on `syncRuntimeApplications()`.
+
+### Task 2: Replace Migration-On-Save With Explicit Canonical Writes
+
+**Files:**
+
+- Modify: `domain/applications/index.ts`
+- Modify: `types/application.ts`
+- Modify: `utils/storageV21Migration.ts`
+- Modify: `utils/services/CaseService.ts`
+- Modify: `hooks/useIntakeWorkflow.ts`
+
+- [ ] **Step 1: Add the minimal domain/application helpers that model explicit canonical application creation and updates**
+
+```ts
+export function createInitialApplicationRecord(input: {
+  applicationId: string;
+  historyId: string;
+  caseId: string;
+  applicantPersonId: string;
+  createdAt: string;
+  caseRecord: Pick<
+    CaseRecord,
+    | "applicationDate"
+    | "applicationType"
+    | "withWaiver"
+    | "retroRequested"
+    | "appValidated"
+    | "retroMonths"
+    | "agedDisabledVerified"
+    | "citizenshipVerified"
+    | "residencyVerified"
+    | "avsConsentDate"
+    | "voterFormStatus"
+    | "intakeCompleted"
+    | "status"
+  >;
+}): Application {
+  return {
+    id: input.applicationId,
+    caseId: input.caseId,
+    applicantPersonId: input.applicantPersonId,
+    applicationDate: input.caseRecord.applicationDate,
+    applicationType: input.caseRecord.applicationType ?? "",
+    status: input.caseRecord.status as Application["status"],
+    statusHistory: [
+      {
+        id: input.historyId,
+        status: input.caseRecord.status as Application["status"],
+        effectiveDate: input.caseRecord.applicationDate,
+        changedAt: input.createdAt,
+        source: "user",
+      },
+    ],
+    hasWaiver: input.caseRecord.withWaiver ?? false,
+    retroRequestedAt: normalizeRetroRequestedAt(
+      input.caseRecord.retroRequested,
+    ),
+    retroMonths: [...(input.caseRecord.retroMonths ?? [])],
+    verification: {
+      isAppValidated: input.caseRecord.appValidated ?? false,
+      isAgedDisabledVerified: input.caseRecord.agedDisabledVerified ?? false,
+      isCitizenshipVerified: input.caseRecord.citizenshipVerified ?? false,
+      isResidencyVerified: input.caseRecord.residencyVerified ?? false,
+      avsConsentDate: input.caseRecord.avsConsentDate ?? "",
+      voterFormStatus: input.caseRecord.voterFormStatus ?? "",
+      isIntakeCompleted: input.caseRecord.intakeCompleted ?? true,
+    },
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+  };
+}
+```
+
+- [ ] **Step 2: Remove the broad storage sync path and keep dehydration purely canonical**
+
+```ts
+export function dehydrateNormalizedData(
+  data: RuntimeNormalizedFileDataV21,
+): PersistedNormalizedFileDataV21 {
+  return {
+    version: "2.1",
+    people: persistedPeople,
+    cases: data.cases.map((caseItem) => dehydrateStoredCase(caseItem)),
+    applications: (data.applications ?? []).map(normalizePersistedApplication),
+    ...
+  };
+}
+```
+
+- [ ] **Step 3: Move canonical application creation into case creation and canonical application updates into intake edit**
+
+```ts
+const createdApplication = createInitialApplicationRecord({
+  applicationId: uuidv4(),
+  historyId: uuidv4(),
+  caseId,
+  applicantPersonId: personId,
+  createdAt: timestamp,
+  caseRecord: newCase.caseRecord,
+});
+
+const updatedData: NormalizedFileData = {
+  ...updatedDataWithPeople,
+  people: updatedPeople,
+  cases: newCases,
+  applications: [...(currentData.applications ?? []), createdApplication],
+};
+```
+
+```ts
+if (isEditing && editableApplication) {
+  await dataManager.updateApplication(
+    activeExistingCase.id,
+    editableApplication.id,
+    {
+      applicationDate: caseRecord.applicationDate,
+      applicationType: caseRecord.applicationType ?? "",
+      hasWaiver: caseRecord.withWaiver ?? false,
+      retroRequestedAt: normalizeRetroRequestedAt(caseRecord.retroRequested),
+      retroMonths: [...(caseRecord.retroMonths ?? [])],
+      verification: {
+        isAppValidated: caseRecord.appValidated ?? false,
+        isAgedDisabledVerified: caseRecord.agedDisabledVerified ?? false,
+        isCitizenshipVerified: caseRecord.citizenshipVerified ?? false,
+        isResidencyVerified: caseRecord.residencyVerified ?? false,
+        avsConsentDate: caseRecord.avsConsentDate ?? "",
+        voterFormStatus: caseRecord.voterFormStatus ?? "",
+        isIntakeCompleted: caseRecord.intakeCompleted ?? true,
+      },
+    },
+  );
+}
+```
+
+- [ ] **Step 4: Run the focused tests again and then the broader related suite**
+
+Run: `npm run test:run -- __tests__/utils/storageV21Migration.test.ts __tests__/hooks/useIntakeWorkflow.test.ts __tests__/services/CaseService.test.ts`
+Then: `npm run test:run`
+Expected: PASS.
+
+### Task 3: Narrow Status Mirroring And Remove Dead Migration Artifacts
+
+**Files:**
+
+- Modify: `utils/services/CaseService.ts`
+- Modify: `utils/services/CaseBulkOperationsService.ts`
+- Modify: `utils/services/FileStorageService.ts`
+- Modify: `domain/applications/migration.ts`
+- Modify: `domain/applications/__tests__/migration.test.ts`
+
+- [ ] **Step 1: Replace status-only application syncing with a narrower selected-application status helper**
+
+```ts
+const synchronizedApplications = syncSelectedApplicationStatuses({
+  applications: caseData.applications ?? [],
+  cases: casesWithTouchedTimestamps,
+  categoryConfig: caseData.categoryConfig,
+  transactionTimestamp: timestamp,
+});
+```
+
+- [ ] **Step 2: Remove the unused migration module and its test coverage once no production imports remain**
+
+Run: `npm run test:run -- domain/applications/__tests__/migration.test.ts`
+Expected: FAIL or no references remain.
+
+- [ ] **Step 3: Delete the dead migration exports and update any remaining imports**
+
+```ts
+export {
+  createInitialApplicationRecord,
+  normalizeRetroRequestedAt,
+} from "./factories";
+export { selectOldestNonTerminalApplication } from "./selectors";
+```
+
+- [ ] **Step 4: Run related tests for case status flows and storage reads**
+
+Run: `npm run test:run -- __tests__/services/FileStorageService.test.ts __tests__/services/CaseService.test.ts __tests__/utils/storageV21Migration.test.ts`
+Expected: PASS.
+
+### Task 4: Update Docs And Verify The Full Slice
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/development/ROADMAP_APR_2026.md`
+- Modify: `docs/development/feature-catalogue.md`
+
+- [ ] **Step 1: Update docs to describe explicit canonical application writes instead of migration-on-save**
+
+```md
+Intake and case creation now write canonical `applications[]` explicitly. Runtime case fields may still be hydrated for compatibility reads, but normal saves no longer reconstruct applications from case-embedded values.
+```
+
+- [ ] **Step 2: Run repo validation**
+
+Run: `npm run typecheck`
+Run: `npm run lint`
+Run: `npm run test:run`
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Record any durable repo-memory update if the write contract changed materially**
+
+```md
+- Application ownership: canonical applications are now written explicitly by case/intake flows; storage dehydration no longer synthesizes them from case fields.
+```

--- a/docs/superpowers/specs/2026-04-09-canonical-workspace-cutover-design.md
+++ b/docs/superpowers/specs/2026-04-09-canonical-workspace-cutover-design.md
@@ -1,0 +1,110 @@
+# Canonical Workspace Cutover Design
+
+## Goal
+
+Land the application migration-bridge cleanup safely by introducing a strict canonical workspace version boundary and resolving the current status-domain mismatch without expanding this PR into the larger configurable-status redesign.
+
+## Scope
+
+This slice covers two decisions:
+
+- move bridge-free canonical application ownership onto a new persisted workspace version
+- stop treating application status as a separate hard-coded domain for this slice by reusing the existing case-status type directly
+
+This slice does not complete the broader status-model redesign. It also does not solve the multi-write atomicity problem introduced by separate case and application updates during intake edit; that remains a follow-up once the persisted schema and status ownership are stable.
+
+## Core Decisions
+
+- Canonical post-bridge workspaces use persisted version `2.2`.
+- Existing bridge-era `2.1` workspaces are treated as legacy-at-load, not as a second valid canonical shape.
+- App startup automatically upgrades a loaded `2.1` workspace to `2.2`, writes the upgraded file back once, shows a one-time notice, and then continues with the upgraded payload.
+- Normal runtime reads operate only on the new canonical version after migration.
+- For this slice, application records reuse the same status type and values as case records rather than mapping into a separate application-status enum.
+- Terminal or completed behavior continues to be determined by configuration semantics such as `countsAsCompleted`, not by a hard-coded application-status vocabulary.
+- The separate, fully config-driven shared status namespace for both case and application records is the next PR, not part of this slice.
+
+## Version Cutover
+
+The current bridge-removal work tightened the meaning of canonical persisted data. Under the old bridge-era behavior, a workspace could still rely on case-embedded legacy application fields and have missing or empty top-level `applications[]` while remaining readable at runtime. After bridge removal, that ambiguity is unsafe because normal dehydration strips application-owned case fields and now writes only the canonical `applications[]` collection.
+
+The design answer is a version cutover, not additional lazy compatibility logic. Persisted version `2.2` becomes the only canonical bridge-free runtime format. Persisted version `2.1` remains migratable, but it is no longer treated as already canonical for normal runtime use.
+
+This keeps the model honest:
+
+- `2.1` means bridge-era normalized workspace
+- `2.2` means canonical post-bridge workspace
+
+For this project, the upgrade flow should be automatic because there is one active operator and one save file. The app should not ask the user to manually run a migration tool before working. Instead, it should detect `2.1`, migrate it forward, persist `2.2`, show a one-time notice that the workspace was upgraded, and then continue with the upgraded payload.
+
+## Runtime Read And Upgrade Flow
+
+The intended startup flow is:
+
+1. Read raw file contents.
+2. If the workspace is already canonical `2.2`, continue normally.
+3. If the workspace is persisted `2.1`, run the explicit upgrade path to canonical `2.2` before normal runtime hydration continues.
+4. Write the upgraded `2.2` file back once.
+5. Surface a lightweight one-time notice that the workspace was upgraded.
+6. Continue all normal runtime behavior against the upgraded `2.2` payload only.
+
+This removes the current ambiguity where a `2.1` file may be structurally readable but semantically non-canonical for bridge-free writes.
+
+Normal runtime read paths should remain strict after this change. They should not continue accepting mixed old and new semantics under the same version label.
+
+## Status Model For This Slice
+
+The current code has a mismatch in intent:
+
+- case status behavior is supposed to be driven primarily by status configuration
+- application records currently define a separate hard-coded application-status domain
+
+The bridge-removal PR exposed that mismatch because canonical application creation now assigns status directly from the case record. Adding a mapping from case status into the current application-status enum would patch the symptom but move the code farther from the intended model.
+
+For this slice, application records should reuse the existing case-status type directly. That means the application record continues to own its own status and status history, but the status value is drawn from the same vocabulary currently used by the case record layer.
+
+This is intentionally transitional. The follow-up PR should remove the remaining hard-coded status assumptions and make both case and application status vocabularies flow through the configurable status namespace.
+
+## Consequences Of The Transitional Status Decision
+
+This slice deliberately chooses the smallest credible correction:
+
+- it removes the unsafe status cast between incompatible domains
+- it avoids inventing a mapping rule that the product does not want
+- it keeps this PR focused on schema cutover and bridge removal rather than a broader workflow rewrite
+
+Known debt intentionally left in place:
+
+- hard-coded case-status typing still exists for one more slice
+- application status temporarily inherits that same typed vocabulary instead of being fully config-driven
+- true shared configurable status ownership across both record types is deferred
+
+## Testing Strategy
+
+Add or update tests to prove the cutover behavior explicitly.
+
+Required coverage:
+
+- loading a persisted `2.1` workspace automatically upgrades it to canonical `2.2`
+- the upgraded file is written back once during the cutover path
+- normal runtime reads continue only after the upgraded `2.2` payload is available
+- bridge-era workspaces with legacy case-embedded application fields do not silently lose application data during the cutover
+- canonical application creation writes a status value valid under the shared case-status type for this slice
+- status-history initialization uses the same status value as the created application record
+
+The tests for this slice do not need to solve the full config-driven status redesign. They only need to prove that status ownership is internally consistent and no longer depends on an invalid cross-domain cast.
+
+## Out Of Scope
+
+- full config-driven shared status namespace across case and application records
+- redesign of status configuration types
+- hook or service refactor for atomic combined case and application writes
+- new UI for migration controls beyond a lightweight upgrade notice
+
+## Follow-Up PR
+
+After this slice lands, the next status-focused PR should:
+
+- remove the separate hard-coded application-status domain entirely
+- align application status and case status around the configurable status namespace
+- preserve only the truly coded semantics such as archival handling and completed or terminal behavior derived from configuration
+- then revisit the split-write atomicity issue once the status and persistence boundaries are stable

--- a/domain/applications/__tests__/migration.test.ts
+++ b/domain/applications/__tests__/migration.test.ts
@@ -1,3 +1,5 @@
+import ts from "typescript";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { createMockCaseRecord } from "@/src/test/testUtils";
@@ -6,6 +8,7 @@ import { APPLICATION_STATUS } from "@/types/application";
 import {
   APPLICATION_OWNED_CASE_RECORD_FIELDS,
   CASE_OWNED_AFTER_APPLICATION_MIGRATION_FIELDS,
+  createCanonicalApplication,
   createMigratedApplication,
   deriveMigratedApplicationStatus,
   normalizeRetroRequestedAt,
@@ -23,6 +26,88 @@ function createMigratedApplicationFromCaseRecord(
     migratedAt: "2026-04-06T10:00:00.000Z",
     caseRecord,
   });
+}
+
+function getCanonicalApplicationStatusTypeDiagnostics() {
+  const projectRoot = process.cwd();
+  const configPath = ts.findConfigFile(projectRoot, ts.sys.fileExists, "tsconfig.json");
+
+  if (!configPath) {
+    throw new Error("Unable to locate tsconfig.json for canonical application status type test.");
+  }
+
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+
+  if (configFile.error) {
+    throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, projectRoot);
+  const virtualFilePath = resolve(
+    projectRoot,
+    "domain/applications/__tests__/canonical-application-status.typecheck.ts",
+  );
+  const virtualSource = [
+    'import { createCanonicalApplication } from "@/domain/applications/migration";',
+    'import type { CaseStatus } from "@/types/case";',
+    "",
+    "const application = createCanonicalApplication({",
+    '  applicationId: "application-1",',
+    '  initialHistoryId: "history-1",',
+    '  caseId: "case-1",',
+    '  applicantPersonId: "person-1",',
+    '  createdAt: "2026-04-09T00:00:00.000Z",',
+    "  caseRecord: {",
+    '    applicationDate: "2026-04-09",',
+    '    applicationType: "Renewal",',
+    "    withWaiver: false,",
+    '    retroRequested: "",',
+    "    appValidated: false,",
+    "    retroMonths: [],",
+    "    agedDisabledVerified: false,",
+    "    citizenshipVerified: false,",
+    "    residencyVerified: false,",
+    '    avsConsentDate: "",',
+    '    voterFormStatus: "",',
+    "    intakeCompleted: true,",
+    '    status: "Active",',
+    "  },",
+    "});",
+    "",
+    "const status: CaseStatus = application.status;",
+    "const historyStatus: CaseStatus = application.statusHistory[0]!.status;",
+    "",
+    "export { status, historyStatus };",
+  ].join("\n");
+
+  const compilerOptions = {
+    ...parsedConfig.options,
+    noEmit: true,
+  };
+  const compilerHost = ts.createCompilerHost(compilerOptions, true);
+  const originalGetSourceFile = compilerHost.getSourceFile.bind(compilerHost);
+
+  compilerHost.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+    if (resolve(fileName) === virtualFilePath) {
+      return ts.createSourceFile(fileName, virtualSource, languageVersion, true);
+    }
+
+    return originalGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+  };
+
+  compilerHost.readFile = (fileName) => (
+    resolve(fileName) === virtualFilePath ? virtualSource : ts.sys.readFile(fileName)
+  );
+  compilerHost.fileExists = (fileName) => (
+    resolve(fileName) === virtualFilePath || ts.sys.fileExists(fileName)
+  );
+
+  const program = ts.createProgram([virtualFilePath], compilerOptions, compilerHost);
+
+  return ts
+    .getPreEmitDiagnostics(program)
+    .filter((diagnostic) => resolve(diagnostic.file?.fileName ?? "") === virtualFilePath)
+    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
 }
 
 describe("APPLICATION_OWNED_CASE_RECORD_FIELDS", () => {
@@ -101,6 +186,46 @@ describe("deriveMigratedApplicationStatus", () => {
       notes:
         "Migrated from legacy case-embedded application fields; v2.1 case status did not distinguish received, withdrawn, approved, or denied application outcomes.",
     });
+  });
+});
+
+describe("createCanonicalApplication", () => {
+  it("creates canonical applications using the case-status value directly without legacy application-status casts", () => {
+    // ARRANGE
+    const caseRecord = createMockCaseRecord({
+      applicationDate: "2026-04-09",
+      applicationType: "Renewal",
+      withWaiver: false,
+      retroRequested: "",
+      appValidated: false,
+      retroMonths: [],
+      agedDisabledVerified: false,
+      citizenshipVerified: false,
+      residencyVerified: false,
+      avsConsentDate: "",
+      voterFormStatus: "",
+      intakeCompleted: true,
+      status: "Active",
+      notes: [],
+      financials: { resources: [], income: [], expenses: [] },
+    });
+
+    // ACT
+    const application = createCanonicalApplication({
+      applicationId: "application-1",
+      initialHistoryId: "history-1",
+      caseId: "case-1",
+      applicantPersonId: "person-1",
+      createdAt: "2026-04-09T00:00:00.000Z",
+      caseRecord,
+    });
+    const diagnostics = getCanonicalApplicationStatusTypeDiagnostics();
+
+    // ASSERT
+    expect(application.status).toBe("Active");
+    expect(application.statusHistory).toHaveLength(1);
+    expect(application.statusHistory[0]).toMatchObject({ status: "Active" });
+    expect(diagnostics).toEqual([]);
   });
 });
 

--- a/domain/applications/index.ts
+++ b/domain/applications/index.ts
@@ -1,11 +1,13 @@
 export {
   APPLICATION_OWNED_CASE_RECORD_FIELDS,
   CASE_OWNED_AFTER_APPLICATION_MIGRATION_FIELDS,
+  createCanonicalApplication,
   createMigratedApplication,
   createMigratedApplicationStatusHistory,
   deriveMigratedApplicationStatus,
   normalizeRetroRequestedAt,
   pickApplicationOwnedCaseRecordFields,
+  type CreateCanonicalApplicationInput,
   type CreateMigratedApplicationInput,
 } from "./migration";
 

--- a/domain/applications/migration.ts
+++ b/domain/applications/migration.ts
@@ -65,23 +65,25 @@ export interface CreateCanonicalApplicationInput {
   caseId: string;
   applicantPersonId: string;
   createdAt: string;
-  caseRecord: Pick<
-    CaseRecord,
-    | "applicationDate"
-    | "applicationType"
-    | "withWaiver"
-    | "retroRequested"
-    | "appValidated"
-    | "retroMonths"
-    | "agedDisabledVerified"
-    | "citizenshipVerified"
-    | "residencyVerified"
-    | "avsConsentDate"
-    | "voterFormStatus"
-    | "intakeCompleted"
-    | "status"
-  >;
+  caseRecord: CanonicalApplicationCaseRecord;
 }
+
+type CanonicalApplicationCaseRecord = Pick<
+  CaseRecord,
+  | "applicationDate"
+  | "applicationType"
+  | "withWaiver"
+  | "retroRequested"
+  | "appValidated"
+  | "retroMonths"
+  | "agedDisabledVerified"
+  | "citizenshipVerified"
+  | "residencyVerified"
+  | "avsConsentDate"
+  | "voterFormStatus"
+  | "intakeCompleted"
+  | "status"
+>;
 
 export function deriveMigratedApplicationStatus(
   caseRecord: Pick<CaseRecord, "status">,
@@ -102,7 +104,7 @@ export function normalizeRetroRequestedAt(
 }
 
 export function pickApplicationOwnedCaseRecordFields(
-  caseRecord: CaseRecord,
+  caseRecord: CanonicalApplicationCaseRecord,
 ): ApplicationOwnedCaseRecordSnapshot {
   return {
     applicationDate: caseRecord.applicationDate,
@@ -188,9 +190,7 @@ export function createMigratedApplication(
 export function createCanonicalApplication(
   input: CreateCanonicalApplicationInput,
 ): Application {
-  const applicationFields = pickApplicationOwnedCaseRecordFields(
-    input.caseRecord as CaseRecord,
-  );
+  const applicationFields = pickApplicationOwnedCaseRecordFields(input.caseRecord);
   const status = input.caseRecord.status;
 
   return {

--- a/domain/applications/migration.ts
+++ b/domain/applications/migration.ts
@@ -59,6 +59,30 @@ export interface CreateMigratedApplicationInput {
   caseRecord: CaseRecord;
 }
 
+export interface CreateCanonicalApplicationInput {
+  applicationId: string;
+  initialHistoryId: string;
+  caseId: string;
+  applicantPersonId: string;
+  createdAt: string;
+  caseRecord: Pick<
+    CaseRecord,
+    | "applicationDate"
+    | "applicationType"
+    | "withWaiver"
+    | "retroRequested"
+    | "appValidated"
+    | "retroMonths"
+    | "agedDisabledVerified"
+    | "citizenshipVerified"
+    | "residencyVerified"
+    | "avsConsentDate"
+    | "voterFormStatus"
+    | "intakeCompleted"
+    | "status"
+  >;
+}
+
 export function deriveMigratedApplicationStatus(
   caseRecord: Pick<CaseRecord, "status">,
 ): MigratedApplicationStatusDecision {
@@ -158,5 +182,48 @@ export function createMigratedApplication(
     },
     createdAt: input.migratedAt,
     updatedAt: input.migratedAt,
+  };
+}
+
+export function createCanonicalApplication(
+  input: CreateCanonicalApplicationInput,
+): Application {
+  const applicationFields = pickApplicationOwnedCaseRecordFields(
+    input.caseRecord as CaseRecord,
+  );
+  const status = input.caseRecord.status as Application["status"];
+
+  return {
+    id: input.applicationId,
+    caseId: input.caseId,
+    applicantPersonId: input.applicantPersonId,
+    applicationDate: applicationFields.applicationDate,
+    applicationType: applicationFields.applicationType,
+    status,
+    statusHistory: [
+      {
+        id: input.initialHistoryId,
+        status,
+        effectiveDate: applicationFields.applicationDate,
+        changedAt: input.createdAt,
+        source: "user",
+      },
+    ],
+    hasWaiver: applicationFields.hasWaiver,
+    retroRequestedAt: normalizeRetroRequestedAt(
+      applicationFields.retroRequested,
+    ),
+    retroMonths: [...applicationFields.retroMonths],
+    verification: {
+      isAppValidated: applicationFields.appValidated,
+      isAgedDisabledVerified: applicationFields.agedDisabledVerified,
+      isCitizenshipVerified: applicationFields.citizenshipVerified,
+      isResidencyVerified: applicationFields.residencyVerified,
+      avsConsentDate: applicationFields.avsConsentDate,
+      voterFormStatus: applicationFields.voterFormStatus,
+      isIntakeCompleted: applicationFields.intakeCompleted,
+    },
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
   };
 }

--- a/domain/applications/migration.ts
+++ b/domain/applications/migration.ts
@@ -191,7 +191,7 @@ export function createCanonicalApplication(
   const applicationFields = pickApplicationOwnedCaseRecordFields(
     input.caseRecord as CaseRecord,
   );
-  const status = input.caseRecord.status as Application["status"];
+  const status = input.caseRecord.status;
 
   return {
     id: input.applicationId,

--- a/domain/applications/selectors.test.ts
+++ b/domain/applications/selectors.test.ts
@@ -9,7 +9,7 @@ import {
   selectOldestNonTerminalApplication,
 } from "@/domain/applications";
 
-const completionStatuses = new Set(["approved", "denied"]);
+const completionStatuses = new Set(["closed", "archived"]);
 
 function selectApplication(
   applications: ReturnType<typeof createMockApplication>[],
@@ -56,7 +56,7 @@ describe("selectOldestNonTerminalApplication", () => {
       createMockApplication({
         id: "application-approved",
         applicationDate: "2026-01-01",
-        status: "Approved",
+        status: "Closed",
       }),
       createMockApplication({
         id: "application-open-oldest",
@@ -137,12 +137,12 @@ describe("selectOldestNonTerminalApplication", () => {
       createMockApplication({
         id: "application-approved",
         applicationDate: "2026-01-01",
-        status: "Approved",
+        status: "Closed",
       }),
       createMockApplication({
         id: "application-denied",
         applicationDate: "2026-02-01",
-        status: "Denied",
+        status: "Archived",
       }),
     ];
 

--- a/hooks/useConnectionFlow.ts
+++ b/hooks/useConnectionFlow.ts
@@ -180,8 +180,9 @@ export function useConnectionFlow({
       toast.success(msg, { id: "connection-success" });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
-      setError(`Failed to load cases: ${message}`);
-      toast.error(`Failed to load cases: ${message}`, { id: "connection-error" });
+      const connectionErrorMessage = `Failed to complete workspace connection: ${message}`;
+      setError(connectionErrorMessage);
+      toast.error(connectionErrorMessage, { id: "connection-error" });
     }
   }, [dataManager, loadCases, setCases, setHasLoadedData, setError, service]);
 

--- a/hooks/useConnectionFlow.ts
+++ b/hooks/useConnectionFlow.ts
@@ -88,7 +88,7 @@ export function useConnectionFlow({
   connectionState,
   service,
   fileStorageService: _fileStorageService,
-  dataManager: _dataManager,
+  dataManager,
   loadCases,
   setCases,
   setError,
@@ -96,6 +96,7 @@ export function useConnectionFlow({
 }: UseConnectionFlowParams): UseConnectionFlowResult {
   const [dismissedModalKey, setDismissedModalKey] = useState<string | null>(null);
   const lastErrorRef = useRef<number | null>(null);
+  const hasShownWorkspaceUpgradeNoticeRef = useRef(false);
 
   const {
     lifecycle,
@@ -149,6 +150,18 @@ export function useConnectionFlow({
   // Called by modal when connection + password is complete
   const handleConnectionComplete = useCallback(async () => {
     try {
+      const migrationReport = dataManager
+        ? await dataManager.migrateWorkspaceToV22()
+        : null;
+
+      if (migrationReport?.summary.migrated && !hasShownWorkspaceUpgradeNoticeRef.current) {
+        hasShownWorkspaceUpgradeNoticeRef.current = true;
+        toast.info("Workspace upgraded to v2.2", {
+          id: "workspace-upgraded",
+          description: "Your saved data was upgraded to the new canonical workspace format.",
+        });
+      }
+
       // Load cases into app state
       const loadedCases = await loadCases();
       setCases(loadedCases);
@@ -170,7 +183,7 @@ export function useConnectionFlow({
       setError(`Failed to load cases: ${message}`);
       toast.error(`Failed to load cases: ${message}`, { id: "connection-error" });
     }
-  }, [loadCases, setCases, setHasLoadedData, setError, service]);
+  }, [dataManager, loadCases, setCases, setHasLoadedData, setError, service]);
 
   // Modal visibility and error sync effect
   useEffect(() => {

--- a/hooks/useIntakeWorkflow.ts
+++ b/hooks/useIntakeWorkflow.ts
@@ -20,7 +20,10 @@ import {
   type SetStateAction,
 } from "react";
 import { toast } from "sonner";
-import { selectOldestNonTerminalApplication } from "@/domain/applications";
+import {
+  normalizeRetroRequestedAt,
+  selectOldestNonTerminalApplication,
+} from "@/domain/applications";
 import { dateInputValueToISO, normalizePhoneNumber } from "@/domain/common";
 import { useDataManagerSafe } from "../contexts/DataManagerContext";
 import { useCategoryConfig } from "../contexts/CategoryConfigContext";
@@ -685,6 +688,31 @@ export function useIntakeWorkflow({
             householdMembers: normalizedHouseholdMembers,
           });
 
+        if (
+          isEditing &&
+          activeExistingCase &&
+          editableApplication &&
+          typeof dataManager.updateApplication === "function" &&
+          !areApplicationFieldsDisabled
+        ) {
+          await dataManager.updateApplication(activeExistingCase.id, editableApplication.id, {
+            applicationDate: caseRecord.applicationDate,
+            applicationType: caseRecord.applicationType ?? "",
+            hasWaiver: caseRecord.withWaiver ?? false,
+            retroRequestedAt: normalizeRetroRequestedAt(caseRecord.retroRequested),
+            retroMonths: [...(caseRecord.retroMonths ?? [])],
+            verification: {
+              isAppValidated: caseRecord.appValidated ?? false,
+              isAgedDisabledVerified: caseRecord.agedDisabledVerified ?? false,
+              isCitizenshipVerified: caseRecord.citizenshipVerified ?? false,
+              isResidencyVerified: caseRecord.residencyVerified ?? false,
+              avsConsentDate: caseRecord.avsConsentDate ?? "",
+              voterFormStatus: caseRecord.voterFormStatus ?? "",
+              isIntakeCompleted: caseRecord.intakeCompleted ?? true,
+            },
+          });
+        }
+
       logger.info(`Intake case ${isEditing ? "updated" : "created"}`, {
         caseId: savedCase.id,
       });
@@ -717,6 +745,7 @@ export function useIntakeWorkflow({
     areApplicationFieldsDisabled,
     dataManager,
     canSubmit,
+      editableApplication,
     formData,
     config,
     isEditing,

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -59,7 +59,7 @@ Object.defineProperty(navigator, 'userAgent', {
 
 // Mock localStorage 
 const localStorageMock = {
-  getItem: vi.fn(),
+  getItem: vi.fn(() => null),
   setItem: vi.fn(),
   removeItem: vi.fn(),
   clear: vi.fn(),

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -6,7 +6,13 @@ import type { FileStorageLifecycleSelectors } from '@/contexts/FileStorageContex
 import { mergeCategoryConfig } from '@/types/categoryConfig'
 import { createBlankHouseholdMemberData, normalizeHouseholdMemberDraft } from '@/domain/cases'
 import type { IntakeFormData } from '@/domain/validation/intake.schema'
-import { dehydrateNormalizedData, type NormalizedFileDataV20, type PersistedNormalizedFileDataV21 } from '@/utils/storageV21Migration'
+import {
+  dehydrateNormalizedData,
+  type NormalizedFileDataV20,
+  type PersistedNormalizedFileDataV21,
+  type PersistedNormalizedFileDataV22,
+  type RuntimeNormalizedFileDataV22,
+} from '@/utils/storageV21Migration'
 import type { DailyActivityReport, CaseActivityLogState } from '@/types/activityLog'
 import type { AlertWithMatch } from '@/utils/alertsData'
 import type { AppNavigationConfig } from '@/components/app/AppNavigationShell'
@@ -226,8 +232,7 @@ export const createMockStoredCase = (overrides: Partial<StoredCase> = {}): Store
 
 export const createMockNormalizedFileData = (
   overrides: Partial<NormalizedFileData> = {},
-): NormalizedFileData => ({
-  version: '2.1',
+): RuntimeNormalizedFileDataV22 => ({
   people: [],
   cases: [],
   applications: [],
@@ -236,6 +241,7 @@ export const createMockNormalizedFileData = (
   alerts: [],
   ...createBaseNormalizedMetadata(),
   ...overrides,
+  version: '2.2',
 })
 
 export const TEST_TRANSACTION_TIMESTAMP = '2026-04-08T10:00:00.000Z'
@@ -290,7 +296,14 @@ export async function withFrozenSystemTime<T>(
 
 export const createMockPersistedNormalizedFileData = (
   overrides: Partial<NormalizedFileData> = {},
-): PersistedNormalizedFileDataV21 => dehydrateNormalizedData(createMockNormalizedFileData(overrides))
+): PersistedNormalizedFileDataV22 => dehydrateNormalizedData(createMockNormalizedFileData(overrides))
+
+export const createMockPersistedNormalizedFileDataV21 = (
+  overrides: Partial<NormalizedFileData> = {},
+): PersistedNormalizedFileDataV21 => ({
+  ...dehydrateNormalizedData(createMockNormalizedFileData(overrides)),
+  version: '2.1',
+})
 
 export const createMockApplication = (
   overrides: Partial<Application> = {},

--- a/types/application.ts
+++ b/types/application.ts
@@ -1,15 +1,13 @@
-import type { CaseStatus, CaseRecord, VoterFormStatus } from "@/types/case";
+import { CASE_STATUS, type CaseStatus, type CaseRecord, type VoterFormStatus } from "@/types/case";
 
 export const APPLICATION_STATUS = {
-  Received: "Received",
-  Pending: "Pending",
-  Withdrawn: "Withdrawn",
-  Approved: "Approved",
-  Denied: "Denied",
+  Active: CASE_STATUS.Active,
+  Pending: CASE_STATUS.Pending,
+  Closed: CASE_STATUS.Closed,
+  Archived: CASE_STATUS.Archived,
 } as const;
 
-export type ApplicationStatus =
-  (typeof APPLICATION_STATUS)[keyof typeof APPLICATION_STATUS];
+export type ApplicationStatus = CaseStatus;
 
 export type ApplicationStatusHistorySource = "migration" | "user";
 

--- a/utils/DataManager.ts
+++ b/utils/DataManager.ts
@@ -64,9 +64,9 @@ import {
   MAIN_WORKSPACE_FILE_NAME,
   buildWorkspaceMigrationReport,
   createEmptyMigrationCounts,
-  migrateArchiveDataToPersistedV21,
+  migrateArchiveDataToPersistedV22,
   summarizeUnknownCounts,
-  validatePersistedV21Data,
+  validatePersistedV22Data,
   type WorkspaceMigrationFileReport,
   type WorkspaceMigrationReport,
 } from "./workspaceV21Migration";
@@ -74,7 +74,9 @@ import { isNormalizedFileData } from "./services/FileStorageService";
 import {
   hydrateNormalizedData,
   isPersistedNormalizedFileDataV20,
+  isPersistedNormalizedFileDataV21,
   migrateV20ToV21,
+  migrateV21ToV22,
 } from "./storageV21Migration";
 
 // ============================================================================
@@ -1516,7 +1518,7 @@ export class DataManager {
    * Explicitly migrate the current workspace and supported archive files to
    * persisted v2.1 format and validate the resulting data.
    */
-  async migrateWorkspaceToV21(): Promise<WorkspaceMigrationReport> {
+  async migrateWorkspaceToV22(): Promise<WorkspaceMigrationReport> {
     const files: WorkspaceMigrationFileReport[] = [];
     const disconnectedMainReport: WorkspaceMigrationFileReport = {
       fileName: MAIN_WORKSPACE_FILE_NAME,
@@ -1570,6 +1572,10 @@ export class DataManager {
     }
 
     return buildWorkspaceMigrationReport(files);
+  }
+
+  async migrateWorkspaceToV21(): Promise<WorkspaceMigrationReport> {
+    return this.migrateWorkspaceToV22();
   }
 
   // =============================================================================
@@ -1716,24 +1722,24 @@ export class DataManager {
       }
 
       if (isNormalizedFileData(rawData)) {
-        const validation = validatePersistedV21Data(rawData);
+        const validation = validatePersistedV22Data(rawData);
         return {
           fileName: MAIN_WORKSPACE_FILE_NAME,
           fileKind: "workspace",
-          disposition: validation.validationErrors.length === 0 ? "already-v2.1" : "failed",
+          disposition: validation.validationErrors.length === 0 ? "already-current" : "failed",
           sourceVersion: rawData.version,
           counts: validation.counts,
           validationErrors: validation.validationErrors,
           message:
             validation.validationErrors.length === 0
-              ? "Already persisted as v2.1."
-              : "Persisted v2.1 validation failed.",
+              ? "Already persisted as v2.2."
+              : "Persisted v2.2 validation failed.",
         };
       }
 
-      if (isPersistedNormalizedFileDataV20(rawData)) {
-        const migratedData = migrateV20ToV21(rawData);
-        const validation = validatePersistedV21Data(migratedData);
+      if (isPersistedNormalizedFileDataV21(rawData)) {
+        const migratedData = migrateV21ToV22(rawData);
+        const validation = validatePersistedV22Data(migratedData);
 
         if (validation.validationErrors.length > 0) {
           return {
@@ -1756,7 +1762,36 @@ export class DataManager {
           sourceVersion: rawData.version,
           counts: validation.counts,
           validationErrors: [],
-          message: "Migrated workspace file to persisted v2.1.",
+          message: "Migrated workspace file to persisted v2.2.",
+        };
+      }
+
+      if (isPersistedNormalizedFileDataV20(rawData)) {
+        const migratedData = migrateV21ToV22(migrateV20ToV21(rawData));
+        const validation = validatePersistedV22Data(migratedData);
+
+        if (validation.validationErrors.length > 0) {
+          return {
+            fileName: MAIN_WORKSPACE_FILE_NAME,
+            fileKind: "workspace",
+            disposition: "failed",
+            sourceVersion: rawData.version,
+            counts: validation.counts,
+            validationErrors: validation.validationErrors,
+            message: "Migration produced integrity errors.",
+          };
+        }
+
+        await this.fileStorage.writeNormalizedData(hydrateNormalizedData(migratedData));
+
+        return {
+          fileName: MAIN_WORKSPACE_FILE_NAME,
+          fileKind: "workspace",
+          disposition: "migrated",
+          sourceVersion: rawData.version,
+          counts: validation.counts,
+          validationErrors: [],
+          message: "Migrated workspace file to persisted v2.2.",
         };
       }
 
@@ -1803,7 +1838,7 @@ export class DataManager {
         };
       }
 
-      const migratedArchive = migrateArchiveDataToPersistedV21(rawData, fileName);
+      const migratedArchive = migrateArchiveDataToPersistedV22(rawData, fileName);
       if (!migratedArchive.data) {
         return {
           fileName,
@@ -1816,7 +1851,7 @@ export class DataManager {
         };
       }
 
-      const validation = validatePersistedV21Data(migratedArchive.data);
+      const validation = validatePersistedV22Data(migratedArchive.data);
       if (validation.validationErrors.length > 0) {
         return {
           fileName,
@@ -1847,13 +1882,13 @@ export class DataManager {
       return {
         fileName,
         fileKind: "archive",
-        disposition: migratedArchive.needsWrite ? "migrated" : "already-v2.1",
+        disposition: migratedArchive.needsWrite ? "migrated" : "already-current",
         sourceVersion: migratedArchive.sourceVersion,
         counts: validation.counts,
         validationErrors: [],
         message: migratedArchive.needsWrite
-          ? "Migrated archive file to persisted v2.1."
-          : "Already persisted as v2.1.",
+          ? "Migrated archive file to persisted v2.2."
+          : "Already persisted as v2.2.",
       };
     } catch (error) {
       return {

--- a/utils/legacyMigration.ts
+++ b/utils/legacyMigration.ts
@@ -28,7 +28,9 @@ import { discoverStatusesFromCases, discoverAlertTypesFromAlerts } from "./categ
 import { createLogger } from "./logger";
 import {
   hydrateNormalizedData,
+  hydratePersistedNormalizedDataV21ForUpgrade,
   isPersistedNormalizedFileDataV20,
+  isPersistedNormalizedFileDataV21,
   migrateV20ToV21,
 } from "./storageV21Migration";
 
@@ -139,7 +141,7 @@ export interface MigrationResult {
  */
 export function detectDataFormat(
   data: unknown,
-): "v2.0" | "v2.1" | "v1.x-nested" | "nightingale-raw" | "unknown" {
+): "v2.0" | "v2.1" | "v2.2" | "v1.x-nested" | "nightingale-raw" | "unknown" {
   if (!data || typeof data !== "object") {
     return "unknown";
   }
@@ -153,6 +155,10 @@ export function detectDataFormat(
 
   if (obj.version === "2.1" && Array.isArray(obj.cases) && Array.isArray(obj.people)) {
     return "v2.1";
+  }
+
+  if (obj.version === "2.2" && Array.isArray(obj.cases) && Array.isArray(obj.people)) {
+    return "v2.2";
   }
 
   // Check for Nightingale raw format
@@ -356,17 +362,32 @@ export function migrateLegacyData(rawData: unknown): MigrationResult {
     logger.info("Starting legacy data migration", { format });
 
       if (format === "v2.1") {
-       if (!isNormalizedFileData(rawData)) {
-         throw new Error(
-           "Detected v2.1 data is missing required normalized structure (people, cases, or associated metadata)",
-         );
-       }
-        logger.info("Data is already in v2.1 format, no migration needed");
-       return {
-         success: true,
-         data: hydrateNormalizedData(rawData),
-         stats,
-         errors,
+        if (!isPersistedNormalizedFileDataV21(rawData)) {
+          throw new Error(
+            "Detected v2.1 data is missing required normalized structure (people, cases, or associated metadata)",
+          );
+        }
+        logger.info("Data is in v2.1 format, upgrading to the canonical v2.2 runtime shape");
+        return {
+          success: true,
+          data: hydratePersistedNormalizedDataV21ForUpgrade(rawData),
+          stats,
+          errors,
+        };
+      }
+
+      if (format === "v2.2") {
+        if (!isNormalizedFileData(rawData)) {
+          throw new Error(
+            "Detected v2.2 data is missing required normalized structure (people, cases, or associated metadata)",
+          );
+        }
+        logger.info("Data is already in v2.2 format, no migration needed");
+        return {
+          success: true,
+          data: hydrateNormalizedData(rawData),
+          stats,
+          errors,
         };
       }
 
@@ -379,7 +400,7 @@ export function migrateLegacyData(rawData: unknown): MigrationResult {
         logger.info("Data is in v2.0 format, migrating to v2.1");
         return {
           success: true,
-          data: hydrateNormalizedData(migrateV20ToV21(rawData)),
+          data: hydratePersistedNormalizedDataV21ForUpgrade(migrateV20ToV21(rawData)),
           stats,
           errors,
         };
@@ -444,7 +465,7 @@ export function migrateLegacyData(rawData: unknown): MigrationResult {
 
     // Build normalized data
     const normalizedData: NormalizedFileData = {
-      version: "2.1",
+      version: "2.2",
       people: cases.map((caseItem) => caseItem.person),
       cases,
       financials,

--- a/utils/legacyMigration.ts
+++ b/utils/legacyMigration.ts
@@ -511,7 +511,9 @@ export function getFormatDescription(format: ReturnType<typeof detectDataFormat>
     case "v2.0":
       return "v2.0 Normalized Format";
     case "v2.1":
-      return "v2.1 Normalized Format (current)";
+      return "v2.1 Normalized Format (upgrade required)";
+    case "v2.2":
+      return "v2.2 Normalized Format (current)";
     case "v1.x-nested":
       return "v1.x Nested Format (legacy)";
     case "nightingale-raw":

--- a/utils/services/CaseBulkOperationsService.ts
+++ b/utils/services/CaseBulkOperationsService.ts
@@ -516,7 +516,7 @@ export class CaseBulkOperationsService {
    */
   async clearAllData(categoryConfig: CategoryConfig): Promise<void> {
     const emptyData: NormalizedFileData = {
-      version: "2.1",
+      version: "2.2",
       people: [],
       cases: [],
       financials: [],

--- a/utils/services/CaseService.ts
+++ b/utils/services/CaseService.ts
@@ -18,6 +18,7 @@ import type { FileStorageService, NormalizedFileData } from './FileStorageServic
 import { ActivityLogService } from './ActivityLogService';
 import { CaseBulkOperationsService } from './CaseBulkOperationsService';
 import { PersonService } from './PersonService';
+import { createCanonicalApplication } from '@/domain/applications';
 import { resolveCaseRecordIntakeCompleted } from '@/domain/cases';
 import { toLocalDateString } from '../../domain/common';
 import { formatCaseDisplayName } from '../../domain/cases/formatting';
@@ -486,19 +487,20 @@ export class CaseService {
     ]);
     const updatedPeople = updatedDataWithPeople.people;
     const newCases = [...currentData.cases, newCase];
+    const createdApplication = createCanonicalApplication({
+      applicationId: uuidv4(),
+      initialHistoryId: uuidv4(),
+      caseId,
+      applicantPersonId: personId,
+      createdAt: timestamp,
+      caseRecord: newCase.caseRecord,
+    });
 
     const updatedData: NormalizedFileData = {
       ...updatedDataWithPeople,
       people: updatedPeople,
       cases: newCases,
-      applications: syncRuntimeApplications(
-        {
-          ...updatedDataWithPeople,
-          people: updatedPeople,
-          cases: newCases,
-        },
-        true,
-      ).applications,
+      applications: [...(currentData.applications ?? []), createdApplication],
     };
 
     const writtenData = await this.fileStorage.writeNormalizedData(updatedData);
@@ -661,8 +663,6 @@ export class CaseService {
       },
       [updatedPerson, ...resolvedHouseholdMembers.map(({ person }) => person)],
     );
-
-    updatedData.applications = syncRuntimeApplications(updatedData, true).applications;
 
     await this.fileStorage.writeNormalizedData(updatedData);
 

--- a/utils/services/CategoryConfigService.ts
+++ b/utils/services/CategoryConfigService.ts
@@ -221,7 +221,7 @@ export class CategoryConfigService {
     const currentData = await this.fileStorage.readFileData();
 
     const baseData: NormalizedFileData = currentData ?? {
-      version: "2.1",
+      version: "2.2",
       people: [],
       cases: [],
       financials: [],

--- a/utils/services/FileStorageService.ts
+++ b/utils/services/FileStorageService.ts
@@ -21,15 +21,16 @@ import {
   dehydrateNormalizedData,
   hydrateNormalizedData,
   hydrateStoredCase,
-  isPersistedNormalizedFileDataV21,
+  isPersistedNormalizedFileDataV22,
   selectDeterministicCanonicalApplication,
-  type PersistedNormalizedFileDataV21,
+  type PersistedNormalizedFileDataV22,
 } from "../storageV21Migration";
 
 const logger = createLogger("FileStorageService");
-const NORMALIZED_VERSION = "2.1";
+const NORMALIZED_VERSION = "2.2";
 const LEGACY_FORMAT_V2_0 = "v2.0";
-const INVALID_V2_1_FORMAT_PREFIX = "invalid v2.1 workspace";
+const LEGACY_FORMAT_V2_1 = "v2.1";
+const INVALID_V2_2_FORMAT_PREFIX = "invalid v2.2 workspace";
 
 /**
  * Deep-copy a single activity log entry, ensuring payload objects are new references.
@@ -75,7 +76,7 @@ export type {
 } from "../../types/case";
 
 /**
- * Normalized file data format (v2.1 runtime shape).
+ * Normalized file data format (current runtime shape).
  *
  * This is the current runtime-ready data format used for file operations.
  * It uses a normalized structure with flat arrays and foreign key references
@@ -84,8 +85,8 @@ export type {
  * @interface NormalizedFileData
  */
 export interface NormalizedFileData {
-  /** Data format version (always "2.1") */
-  version: "2.1";
+  /** Data format version (current canonical writes persist as "2.2") */
+  version: "2.2";
   /** Global people registry available to services and future UI flows */
   people: Person[];
   /** Runtime-hydrated cases */
@@ -116,7 +117,7 @@ export interface CaseDehydratedNormalizedFileData extends Omit<NormalizedFileDat
 
 type NormalizedWriteData =
   | NormalizedFileData
-  | PersistedNormalizedFileDataV21
+  | PersistedNormalizedFileDataV22
   | CaseDehydratedNormalizedFileData;
 
 function cloneApplicationForWrite(application: Application): Application {
@@ -159,23 +160,23 @@ function isCaseDehydratedNormalizedWriteData(
 }
 
 /**
- * Type guard to check if data matches the persisted normalized v2.1 format.
+ * Type guard to check if data matches the persisted normalized v2.2 format.
  * 
  * @param {unknown} data - Data to check
  * @returns {boolean} true if data is NormalizedFileData
  */
-export function isNormalizedFileData(data: unknown): data is PersistedNormalizedFileDataV21 {
-  return isPersistedNormalizedFileDataV21(data);
+export function isNormalizedFileData(data: unknown): data is PersistedNormalizedFileDataV22 {
+  return isPersistedNormalizedFileDataV22(data);
 }
 
 /**
  * Error thrown when attempting to load a workspace file outside the canonical
- * persisted v2.1 format accepted by the normal app runtime.
+ * persisted v2.2 format accepted by the normal app runtime.
  * 
  * This error is thrown when the file format is detected as legacy, v2.0, or an
- * invalid/non-canonical v2.1 payload. It provides a user-facing message that
- * points users toward the explicit migration tooling instead of silently
- * rewriting the workspace during normal reads.
+ * invalid/non-canonical v2.2 payload. It provides a user-facing message that
+ * points users toward the current upgrade flow instead of silently rewriting
+ * the workspace during normal reads.
  * 
  * @class LegacyFormatError
  * @extends Error
@@ -189,8 +190,9 @@ export class LegacyFormatError extends Error {
   constructor(detectedFormat: string) {
     const migrationGuidance =
       detectedFormat === LEGACY_FORMAT_V2_0 ||
-      detectedFormat.startsWith(INVALID_V2_1_FORMAT_PREFIX)
-        ? `Use the persisted v${NORMALIZED_VERSION} migration tool in Settings → Diagnostics, then reopen the workspace.`
+      detectedFormat === LEGACY_FORMAT_V2_1 ||
+      detectedFormat.startsWith(INVALID_V2_2_FORMAT_PREFIX)
+        ? `This workspace must be upgraded to persisted v${NORMALIZED_VERSION} before normal runtime operations continue.`
         : `Use the available migration tooling or contact support for assistance moving this data to v${NORMALIZED_VERSION}.`;
 
     super(
@@ -319,22 +321,22 @@ export class FileStorageService {
   }
 
   /**
- * Read current data from file system in canonical normalized v2.1 runtime format.
+ * Read current data from file system in canonical normalized v2.2 runtime format.
  *
    * This is the primary read method that:
    * 1. Reads file via AutosaveFileService
    * 2. Validates format version
- * 3. Hydrates persisted v2.1 data for runtime consumers
-  * 4. Rejects v2.0/legacy/non-canonical payloads with LegacyFormatError
-  * 5. Keeps manual migration tooling on the explicit migration path only
+ * 3. Hydrates persisted v2.2 data for runtime consumers
+  * 4. Rejects v2.1/v2.0/legacy/non-canonical payloads with LegacyFormatError
+  * 5. Keeps upgrade tooling on the explicit migration path only
  *
    * **Behavior:**
    * - Returns null if no workspace file exists yet
-  * - Throws LegacyFormatError for v2.0, pre-v2.0, or invalid persisted v2.1 formats
+  * - Throws LegacyFormatError for v2.1, v2.0, pre-v2.0, or invalid persisted v2.2 formats
  * - Throws Error for other read failures
  *
    * @returns {Promise<NormalizedFileData | null>} Normalized data or null
-   * @throws {LegacyFormatError} If file is not canonical persisted v2.1 data
+  * @throws {LegacyFormatError} If file is not canonical persisted v2.2 data
    * @throws {Error} If file read fails for other reasons
    * 
    * @example
@@ -388,7 +390,7 @@ export class FileStorageService {
  * This method bypasses format validation and returns the raw persisted file contents.
    * **Only for use by migration utilities** that need to read legacy formats.
    * 
- * Normal application code should use readFileData() which enforces v2.1 format.
+ * Normal application code should use readFileData() which enforces v2.2 format.
  *
    * @returns {Promise<unknown>} Raw file data or null if no file exists
    * @throws {Error} If file read fails
@@ -406,9 +408,9 @@ export class FileStorageService {
   }
 
   private async readCanonicalNormalizedData(
-    rawData: PersistedNormalizedFileDataV21,
+    rawData: PersistedNormalizedFileDataV22,
   ): Promise<NormalizedFileData> {
-    logger.debug("Detected normalized data format (v2.1)");
+    logger.debug("Detected normalized data format (v2.2)");
 
     const hydratedData = this.hydratePersistedRuntimeData(rawData);
     const { normalizedData, hasFinancialMigration } = this.applyFinancialMigration(
@@ -423,19 +425,19 @@ export class FileStorageService {
   }
 
   private hydratePersistedRuntimeData(
-    rawData: PersistedNormalizedFileDataV21,
+    rawData: PersistedNormalizedFileDataV22,
   ): NormalizedFileData {
     try {
       return hydrateNormalizedData(rawData);
     } catch (error) {
-      logger.error("Persisted v2.1 data failed canonical hydration", {
+      logger.error("Persisted v2.2 data failed canonical hydration", {
         error: error instanceof Error ? error.message : "Unknown error",
       });
       const hydrationError =
         error instanceof Error && error.message.trim().length > 0
           ? error.message
           : "unknown hydration error";
-      throw new LegacyFormatError(`${INVALID_V2_1_FORMAT_PREFIX}: ${hydrationError}`);
+      throw new LegacyFormatError(`${INVALID_V2_2_FORMAT_PREFIX}: ${hydrationError}`);
     }
   }
 
@@ -515,8 +517,12 @@ export class FileStorageService {
       return LEGACY_FORMAT_V2_0;
     }
 
+    if (obj.version === LEGACY_FORMAT_V2_1) {
+      return LEGACY_FORMAT_V2_1;
+    }
+
     if (obj.version === NORMALIZED_VERSION) {
-      return INVALID_V2_1_FORMAT_PREFIX;
+      return INVALID_V2_2_FORMAT_PREFIX;
     }
 
     return `v${obj.version}`;
@@ -555,14 +561,14 @@ export class FileStorageService {
    * 
    * The `data` argument can be provided in three closely related shapes:
    * - `NormalizedFileData`: runtime-ready normalized data used throughout the app.
-   * - `PersistedNormalizedFileDataV21`: hydrated persisted v2.1 storage shape.
+  * - `PersistedNormalizedFileDataV22`: canonical persisted v2.2 storage shape.
    * - `CaseDehydratedNormalizedFileData`: normalized data where cases have been
    *   "dehydrated" to their persisted form (typically produced by
    *   `dehydrateNormalizedData` for efficient writes/broadcasts and usually not
    *   hand-authored by callers).
    *
-   * @param {NormalizedFileData | PersistedNormalizedFileDataV21 | CaseDehydratedNormalizedFileData} data - Normalized
-   *   runtime data, persisted-style v2.1 data, or case-dehydrated normalized data
+  * @param {NormalizedFileData | PersistedNormalizedFileDataV22 | CaseDehydratedNormalizedFileData} data - Normalized
+  *   runtime data, persisted-style v2.2 data, or case-dehydrated normalized data
    *   to write through the canonical storage path
    * @returns {Promise<NormalizedFileData>} The written data after enrichment
    * @throws {Error} If write operation fails
@@ -659,7 +665,7 @@ export class FileStorageService {
 
   private buildFinalWriteData(runtimeData: NormalizedFileData): NormalizedFileData {
     return {
-      version: NORMALIZED_VERSION as "2.1",
+      version: NORMALIZED_VERSION as "2.2",
       people: runtimeData.people.map((person) => ({ ...person })),
       cases: runtimeData.cases.map((caseItem) => ({ ...caseItem })),
       applications: runtimeData.applications?.map(cloneApplicationForWrite),

--- a/utils/services/FileStorageService.ts
+++ b/utils/services/FileStorageService.ts
@@ -22,9 +22,7 @@ import {
   hydrateNormalizedData,
   hydrateStoredCase,
   isPersistedNormalizedFileDataV21,
-  persistedCasesContainLegacyApplicationFields,
   selectDeterministicCanonicalApplication,
-  syncRuntimeApplications,
   type PersistedNormalizedFileDataV21,
 } from "../storageV21Migration";
 
@@ -413,22 +411,11 @@ export class FileStorageService {
     logger.debug("Detected normalized data format (v2.1)");
 
     const hydratedData = this.hydratePersistedRuntimeData(rawData);
-    const { canonicalData, shouldRewriteApplications } = this.syncReadApplications(
-      rawData,
+    const { normalizedData, hasFinancialMigration } = this.applyFinancialMigration(
       hydratedData,
     );
-    const { normalizedData, hasFinancialMigration } = this.applyFinancialMigration(
-      canonicalData,
-    );
 
-    if (shouldRewriteApplications) {
-      logger.info("Migrated workspace applications into canonical persisted records", {
-        caseCount: normalizedData.cases.length,
-        applicationCount: normalizedData.applications?.length ?? 0,
-      });
-    }
-
-    if (shouldRewriteApplications || hasFinancialMigration) {
+    if (hasFinancialMigration) {
       return await this.writeNormalizedData(normalizedData);
     }
 
@@ -450,28 +437,6 @@ export class FileStorageService {
           : "unknown hydration error";
       throw new LegacyFormatError(`${INVALID_V2_1_FORMAT_PREFIX}: ${hydrationError}`);
     }
-  }
-
-  private syncReadApplications(
-    rawData: PersistedNormalizedFileDataV21,
-    hydratedData: NormalizedFileData,
-  ): { canonicalData: NormalizedFileData; shouldRewriteApplications: boolean } {
-    const { applications: syncedApplications, hasChanged } =
-      syncRuntimeApplications(hydratedData);
-    const shouldRewriteApplications =
-      hasChanged ||
-      persistedCasesContainLegacyApplicationFields(rawData.cases) ||
-      ((rawData.applications?.length ?? 0) === 0 && rawData.cases.length > 0);
-
-    return {
-      canonicalData: hasChanged
-        ? {
-            ...hydratedData,
-            applications: syncedApplications,
-          }
-        : hydratedData,
-      shouldRewriteApplications,
-    };
   }
 
   private applyFinancialMigration(

--- a/utils/storageV21Migration.ts
+++ b/utils/storageV21Migration.ts
@@ -1182,6 +1182,9 @@ export function migrateV20ToV21(data: NormalizedFileDataV20): PersistedNormalize
           ...caseItem.caseRecord,
           id: caseItem.id,
           personId: migratedPersonId,
+          intakeCompleted: resolveCaseRecordIntakeCompleted(
+            caseItem.caseRecord.intakeCompleted,
+          ),
           financials: {
             resources: [],
             income: [],
@@ -1209,6 +1212,7 @@ export function migrateV21ToV22(
   const syncedData = syncRuntimeApplications(hydratedData, {
     preferRuntimeCaseFields: true,
     syncMode: "full",
+    transactionTimestamp: data.exported_at,
   });
 
   return dehydrateNormalizedData({

--- a/utils/storageV21Migration.ts
+++ b/utils/storageV21Migration.ts
@@ -948,7 +948,6 @@ export function hydrateNormalizedData(
 export function dehydrateNormalizedData(
   data: RuntimeNormalizedFileDataV21,
 ): PersistedNormalizedFileDataV21 {
-  const { applications } = syncRuntimeApplications(data);
   const peopleRegistry = new Map<string, Person>();
 
   for (const person of data.people) {
@@ -969,7 +968,7 @@ export function dehydrateNormalizedData(
     version: "2.1",
     people: persistedPeople,
     cases: data.cases.map((caseItem) => dehydrateStoredCase(caseItem)),
-    applications: applications.map(normalizePersistedApplication),
+    applications: (data.applications ?? []).map(normalizePersistedApplication),
     financials: data.financials.map((financial) => ({ ...financial })),
     notes: data.notes.map((note) => ({ ...note })),
     alerts: data.alerts.map((alert) => ({ ...alert })),
@@ -1114,6 +1113,31 @@ export function migrateV20ToV21(data: NormalizedFileDataV20): PersistedNormalize
         },
         isPendingArchival: caseItem.isPendingArchival,
       };
+    }),
+    applications: data.cases.map((caseItem) => {
+      const migratedPersonId = casePersonIds.get(caseItem.id);
+      if (!migratedPersonId) {
+        throw new Error(`Missing migrated person ID for case ${caseItem.id}`);
+      }
+
+      return createMigratedApplication({
+        applicationId: uuidv4(),
+        initialHistoryId: uuidv4(),
+        caseId: caseItem.id,
+        applicantPersonId: migratedPersonId,
+        migratedAt: caseItem.updatedAt || caseItem.createdAt || data.exported_at,
+        caseRecord: {
+          ...caseItem.caseRecord,
+          id: caseItem.id,
+          personId: migratedPersonId,
+          financials: {
+            resources: [],
+            income: [],
+            expenses: [],
+          },
+          notes: [],
+        },
+      });
     }),
     financials: data.financials.map((financial) => ({ ...financial })),
     notes: data.notes.map((note) => ({ ...note })),

--- a/utils/storageV21Migration.ts
+++ b/utils/storageV21Migration.ts
@@ -73,6 +73,36 @@ export interface RuntimeNormalizedFileDataV21 {
   templates?: Template[];
 }
 
+export interface PersistedNormalizedFileDataV22 {
+  version: "2.2";
+  people: StoredPerson[];
+  cases: PersistedCase[];
+  applications?: Application[];
+  financials: StoredFinancialItem[];
+  notes: StoredNote[];
+  alerts: AlertRecord[];
+  exported_at: string;
+  total_cases: number;
+  categoryConfig: CategoryConfig;
+  activityLog: CaseActivityEntry[];
+  templates?: Template[];
+}
+
+export interface RuntimeNormalizedFileDataV22 {
+  version: "2.2";
+  people: Person[];
+  cases: StoredCase[];
+  applications?: Application[];
+  financials: StoredFinancialItem[];
+  notes: StoredNote[];
+  alerts: AlertRecord[];
+  exported_at: string;
+  total_cases: number;
+  categoryConfig: CategoryConfig;
+  activityLog: CaseActivityEntry[];
+  templates?: Template[];
+}
+
 function cloneApplicationStatusHistory(
   statusHistory: Application["statusHistory"],
 ): Application["statusHistory"] {
@@ -171,6 +201,16 @@ export function isPersistedNormalizedFileDataV21(data: unknown): data is Persist
 
   return (
     candidate?.version === "2.1" &&
+    Array.isArray(candidate.people) &&
+    hasNormalizedCollectionsAndMetadata(candidate)
+  );
+}
+
+export function isPersistedNormalizedFileDataV22(data: unknown): data is PersistedNormalizedFileDataV22 {
+  const candidate = toNormalizedDataShapeCandidate(data);
+
+  return (
+    candidate?.version === "2.2" &&
     Array.isArray(candidate.people) &&
     hasNormalizedCollectionsAndMetadata(candidate)
   );
@@ -649,7 +689,7 @@ function syncApplicationWithCase(
   syncMode: RuntimeApplicationSyncMode = "full",
 ): { application: Application; hasChanged: boolean } {
   const sourceCaseRecord = createApplicationSourceCase(caseItem);
-  const nextStatus = sourceCaseRecord.status as Application["status"];
+  const nextStatus = sourceCaseRecord.status;
 
   if (!existingApplication) {
     return {
@@ -769,7 +809,7 @@ function shouldSkipApplicationSync(
 }
 
 export function syncRuntimeApplications(
-  data: RuntimeNormalizedFileDataV21,
+  data: RuntimeNormalizedFileDataV22,
   optionsOrPreferRuntimeCaseFields: boolean | SyncRuntimeApplicationsOptions = false,
 ): { applications: Application[]; hasChanged: boolean } {
   const {
@@ -911,15 +951,15 @@ export function dehydrateStoredCase(caseItem: StoredCase): PersistedCase {
   };
 }
 
-export function hydrateNormalizedData(
-  data: PersistedNormalizedFileDataV21,
-): RuntimeNormalizedFileDataV21 {
+function hydratePersistedNormalizedData(
+  data: PersistedNormalizedFileDataV21 | PersistedNormalizedFileDataV22,
+): RuntimeNormalizedFileDataV22 {
   const people = data.people.map((person) => toRuntimePerson(person, data.people));
   const applications = data.applications?.map(normalizePersistedApplication) ?? [];
   const completionStatuses = getCompletionStatusNames(data.categoryConfig);
 
   return {
-    version: "2.1",
+    version: "2.2",
     people,
     cases: data.cases.map((caseItem) =>
       hydrateStoredCase(
@@ -946,8 +986,8 @@ export function hydrateNormalizedData(
 }
 
 export function dehydrateNormalizedData(
-  data: RuntimeNormalizedFileDataV21,
-): PersistedNormalizedFileDataV21 {
+  data: RuntimeNormalizedFileDataV22,
+): PersistedNormalizedFileDataV22 {
   const peopleRegistry = new Map<string, Person>();
 
   for (const person of data.people) {
@@ -965,7 +1005,7 @@ export function dehydrateNormalizedData(
   const persistedPeople = people.map((person) => toStoredPerson(person, people));
 
   return {
-    version: "2.1",
+    version: "2.2",
     people: persistedPeople,
     cases: data.cases.map((caseItem) => dehydrateStoredCase(caseItem)),
     applications: (data.applications ?? []).map(normalizePersistedApplication),
@@ -978,6 +1018,18 @@ export function dehydrateNormalizedData(
     activityLog: data.activityLog.map((entry) => ({ ...entry })),
     templates: data.templates ? [...data.templates] : undefined,
   };
+}
+
+export function hydrateNormalizedData(
+  data: PersistedNormalizedFileDataV22,
+): RuntimeNormalizedFileDataV22 {
+  return hydratePersistedNormalizedData(data);
+}
+
+export function hydratePersistedNormalizedDataV21ForUpgrade(
+  data: PersistedNormalizedFileDataV21,
+): RuntimeNormalizedFileDataV22 {
+  return hydratePersistedNormalizedData(data);
 }
 
 function migrateRelationship(
@@ -1148,4 +1200,19 @@ export function migrateV20ToV21(data: NormalizedFileDataV20): PersistedNormalize
     activityLog: data.activityLog.map((entry) => ({ ...entry })),
     templates: data.templates ? [...data.templates] : undefined,
   };
+}
+
+export function migrateV21ToV22(
+  data: PersistedNormalizedFileDataV21,
+): PersistedNormalizedFileDataV22 {
+  const hydratedData = hydratePersistedNormalizedDataV21ForUpgrade(data);
+  const syncedData = syncRuntimeApplications(hydratedData, {
+    preferRuntimeCaseFields: true,
+    syncMode: "full",
+  });
+
+  return dehydrateNormalizedData({
+    ...hydratedData,
+    applications: syncedData.applications,
+  });
 }

--- a/utils/workspaceV21Migration.ts
+++ b/utils/workspaceV21Migration.ts
@@ -4,9 +4,14 @@ import { mergeCategoryConfig } from "@/types/categoryConfig";
 import {
   dehydrateNormalizedData,
   hydrateNormalizedData,
+  hydratePersistedNormalizedDataV21ForUpgrade,
   isPersistedNormalizedFileDataV20,
+  isPersistedNormalizedFileDataV21,
+  isPersistedNormalizedFileDataV22,
   migrateV20ToV21,
+  migrateV21ToV22,
   type PersistedNormalizedFileDataV21,
+  type PersistedNormalizedFileDataV22,
 } from "@/utils/storageV21Migration";
 import { isCaseArchiveData, parseArchiveYear } from "@/types/archive";
 import {
@@ -18,6 +23,7 @@ export const MAIN_WORKSPACE_FILE_NAME = "case-tracker-data.json";
 
 export type WorkspaceMigrationDisposition =
   | "already-v2.1"
+  | "already-current"
   | "migrated"
   | "failed"
   | "skipped";
@@ -52,6 +58,12 @@ export interface WorkspaceMigrationReport {
 }
 
 export interface PersistedCaseArchiveDataV21 extends PersistedNormalizedFileDataV21 {
+  archiveType: "cases";
+  archiveYear: number;
+  archivedAt: string;
+}
+
+export interface PersistedCaseArchiveDataV22 extends PersistedNormalizedFileDataV22 {
   archiveType: "cases";
   archiveYear: number;
   archivedAt: string;
@@ -98,7 +110,7 @@ export function summarizeUnknownCounts(data: unknown): WorkspaceMigrationCounts 
 }
 
 export function isPersistedCaseArchiveDataV21(data: unknown): data is PersistedCaseArchiveDataV21 {
-  if (!isNormalizedFileData(data)) {
+  if (!isPersistedNormalizedFileDataV21(data)) {
     return false;
   }
 
@@ -125,7 +137,59 @@ function cloneArchiveCases(cases: CaseArchiveData["cases"]): CaseArchiveData["ca
 
 export function buildPersistedArchiveDataV21(archiveData: CaseArchiveData): PersistedCaseArchiveDataV21 {
   const runtimeNormalizedData: NormalizedFileData = {
+    version: "2.2",
+    people: [],
+    cases: cloneArchiveCases(archiveData.cases),
+    financials: archiveData.financials.map((financial) => ({ ...financial })),
+    notes: archiveData.notes.map((note) => ({ ...note })),
+    alerts: [],
+    exported_at: archiveData.archivedAt,
+    total_cases: archiveData.cases.length,
+    categoryConfig: mergeCategoryConfig(),
+    activityLog: [],
+  };
+
+  const persistedData = dehydrateNormalizedData(runtimeNormalizedData);
+
+  return {
+    ...persistedData,
     version: "2.1",
+    archiveType: "cases",
+    archiveYear: archiveData.archiveYear,
+    archivedAt: archiveData.archivedAt,
+  };
+}
+
+export function hydratePersistedArchiveDataV21(data: PersistedCaseArchiveDataV21): CaseArchiveData {
+  const hydratedData = hydratePersistedNormalizedDataV21ForUpgrade(data);
+
+  return {
+    version: "1.0",
+    archiveType: "cases",
+    archivedAt: data.archivedAt,
+    archiveYear: data.archiveYear,
+    cases: hydratedData.cases,
+    financials: hydratedData.financials,
+    notes: hydratedData.notes,
+  };
+}
+
+export function isPersistedCaseArchiveDataV22(data: unknown): data is PersistedCaseArchiveDataV22 {
+  if (!isPersistedNormalizedFileDataV22(data)) {
+    return false;
+  }
+
+  const candidate = data as unknown as Record<string, unknown>;
+  return (
+    candidate.archiveType === "cases" &&
+    typeof candidate.archivedAt === "string" &&
+    typeof candidate.archiveYear === "number"
+  );
+}
+
+export function buildPersistedArchiveDataV22(archiveData: CaseArchiveData): PersistedCaseArchiveDataV22 {
+  const runtimeNormalizedData: NormalizedFileData = {
+    version: "2.2",
     people: [],
     cases: cloneArchiveCases(archiveData.cases),
     financials: archiveData.financials.map((financial) => ({ ...financial })),
@@ -147,7 +211,7 @@ export function buildPersistedArchiveDataV21(archiveData: CaseArchiveData): Pers
   };
 }
 
-export function hydratePersistedArchiveDataV21(data: PersistedCaseArchiveDataV21): CaseArchiveData {
+export function hydratePersistedArchiveDataV22(data: PersistedCaseArchiveDataV22): CaseArchiveData {
   const hydratedData = hydrateNormalizedData(data);
 
   return {
@@ -303,7 +367,7 @@ export function validatePersistedV21Data(
       // At this point the required root collections/metadata exist and every
       // case/person link has passed explicit integrity checks, so hydration is
       // safe to use as the final canonical validation step.
-      hydrateNormalizedData(data as PersistedNormalizedFileDataV21);
+      hydratePersistedNormalizedDataV21ForUpgrade(data as PersistedNormalizedFileDataV21);
     } catch (error) {
       validationErrors.push(
         `Canonical hydration failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -314,6 +378,37 @@ export function validatePersistedV21Data(
   return {
     counts,
     validationErrors,
+  };
+}
+
+export function validatePersistedV22Data(
+  data: unknown,
+): { counts: WorkspaceMigrationCounts; validationErrors: string[] } {
+  if (data === null || typeof data !== "object" || Array.isArray(data)) {
+    return {
+      counts: createEmptyMigrationCounts(),
+      validationErrors: ['Expected a persisted v2.2 object but found a non-object value.'],
+    };
+  }
+
+  const candidate = data as Record<string, unknown>;
+  const legacyValidation = validatePersistedV21Data({
+    ...candidate,
+    version: "2.1",
+  });
+  const filteredValidationErrors = legacyValidation.validationErrors.filter(
+    (error) => !error.startsWith('Expected version "2.1"'),
+  );
+
+  if (candidate.version !== "2.2") {
+    filteredValidationErrors.unshift(
+      `Expected version "2.2" but found "${String(candidate.version)}".`,
+    );
+  }
+
+  return {
+    counts: legacyValidation.counts,
+    validationErrors: filteredValidationErrors,
   };
 }
 
@@ -349,6 +444,7 @@ export function migrateArchiveDataToPersistedV21(
     return {
       data: {
         ...rawData,
+        version: "2.1",
         archiveType: "cases",
         archiveYear,
         archivedAt: rawData.exported_at,
@@ -390,6 +486,93 @@ export function migrateArchiveDataToPersistedV21(
   };
 }
 
+export function migrateArchiveDataToPersistedV22(
+  rawData: unknown,
+  fileName: string,
+): {
+  data: PersistedCaseArchiveDataV22 | null;
+  sourceVersion: string | null;
+  error: string | null;
+  needsWrite: boolean;
+} {
+  const archiveYear = parseArchiveYear(fileName);
+  if (archiveYear === null) {
+    return {
+      data: null,
+      sourceVersion: null,
+      error: `Unsupported archive file name: ${fileName}`,
+      needsWrite: false,
+    };
+  }
+
+  if (isPersistedCaseArchiveDataV22(rawData)) {
+    return {
+      data: rawData,
+      sourceVersion: rawData.version,
+      error: null,
+      needsWrite: false,
+    };
+  }
+
+  if (isPersistedCaseArchiveDataV21(rawData)) {
+    return {
+      data: {
+        ...migrateV21ToV22(rawData),
+        archiveType: "cases",
+        archiveYear,
+        archivedAt: rawData.archivedAt,
+      },
+      sourceVersion: rawData.version,
+      error: null,
+      needsWrite: true,
+    };
+  }
+
+  if (isNormalizedFileData(rawData)) {
+    return {
+      data: {
+        ...rawData,
+        archiveType: "cases",
+        archiveYear,
+        archivedAt: rawData.exported_at,
+      },
+      sourceVersion: rawData.version,
+      error: null,
+      needsWrite: true,
+    };
+  }
+
+  if (isPersistedNormalizedFileDataV20(rawData)) {
+    return {
+      data: {
+        ...migrateV21ToV22(migrateV20ToV21(rawData)),
+        archiveType: "cases",
+        archiveYear,
+        archivedAt: rawData.exported_at,
+      },
+      sourceVersion: rawData.version,
+      error: null,
+      needsWrite: true,
+    };
+  }
+
+  if (isCaseArchiveData(rawData)) {
+    return {
+      data: buildPersistedArchiveDataV22(rawData),
+      sourceVersion: rawData.version,
+      error: null,
+      needsWrite: true,
+    };
+  }
+
+  return {
+    data: null,
+    sourceVersion: null,
+    error: `Unsupported archive data format in ${fileName}.`,
+    needsWrite: false,
+  };
+}
+
 export function buildWorkspaceMigrationReport(
   files: WorkspaceMigrationFileReport[],
 ): WorkspaceMigrationReport {
@@ -398,7 +581,9 @@ export function buildWorkspaceMigrationReport(
     files,
     summary: {
       migrated: files.filter((file) => file.disposition === "migrated").length,
-      alreadyV21: files.filter((file) => file.disposition === "already-v2.1").length,
+      alreadyV21: files.filter(
+        (file) => file.disposition === "already-v2.1" || file.disposition === "already-current",
+      ).length,
       failed: files.filter((file) => file.disposition === "failed").length,
       skipped: files.filter((file) => file.disposition === "skipped").length,
     },


### PR DESCRIPTION
## Summary
- stop normal runtime reads and writes from synthesizing canonical `applications[]` from case compatibility fields
- create canonical applications explicitly for new cases and editable intake updates while preserving explicit v2.0 to v2.1 migration behavior
- update regression tests and docs for the bridge-free runtime write contract

## Testing
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic workspace upgrade to v2.2 on first connection with a one‑time "Workspace upgraded to v2.2" notice.

* **Bug Fixes**
  * Normal runtime reads now reject legacy v2.1/v2.0 until migrated.
  * Runtime reads/stores no longer synthesize or rewrite canonical application entries.

* **Refactor**
  * Canonical applications are created/updated only during create/edit flows (ordinary saves no longer rebuild applications).

* **Documentation**
  * Docs, roadmaps, plans, and specs updated to describe v2.2 and the upgrade/cutover plan.

* **Tests**
  * Test suites and fixtures updated for v2.2 and status labels (Approved→Closed, Denied→Archived).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->